### PR TITLE
Add item quantity and bag tracking features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,14 @@
 At the end of every work task, always:
 
 1. Compile: `./gradlew assembleDebug`
-2. Run tests: `./gradlew connectedDebugAndroidTest` (requires a running emulator)
+2. Build test APK: `./gradlew assembleDebugAndroidTest`
+3. Run tests via adb (requires a running emulator):
+```bash
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+adb install -r app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+adb shell am instrument -w me.robwilliams.pack.test/androidx.test.runner.AndroidJUnitRunner
+```
 
-Do not consider work complete until both pass.
+Do not consider work complete until both build and tests pass.
+
+Note: Do NOT use `./gradlew connectedDebugAndroidTest` — it uninstalls and reinstalls the app, wiping the database on the emulator. The adb approach above preserves app data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+## Verification
+
+At the end of every work task, always:
+
+1. Compile: `./gradlew assembleDebug`
+2. Run tests: `./gradlew connectedDebugAndroidTest` (requires a running emulator)
+
+Do not consider work complete until both pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,15 @@
 At the end of every work task, always:
 
 1. Compile: `./gradlew assembleDebug`
-2. Build test APK: `./gradlew assembleDebugAndroidTest`
-3. Run tests via adb (requires a running emulator):
+2. Run unit tests: `./gradlew testDebugUnitTest`
+3. Build test APK and run instrumented tests via adb (requires a running emulator):
 ```bash
+./gradlew assembleDebugAndroidTest
 adb install -r app/build/outputs/apk/debug/app-debug.apk
 adb install -r app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 adb shell am instrument -w me.robwilliams.pack.test/androidx.test.runner.AndroidJUnitRunner
 ```
 
-Do not consider work complete until both build and tests pass.
+Do not consider work complete until build and all tests pass.
 
 Note: Do NOT use `./gradlew connectedDebugAndroidTest` — it uninstalls and reinstalls the app, wiping the database on the emulator. The adb approach above preserves app data.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,9 @@ This way, debug builds use debug OAuth and release builds use release OAuth auto
 
 Instrumentation tests require a running emulator or connected device.
 
-```bash
-# Run all instrumented tests via Gradle
-./gradlew connectedDebugAndroidTest
+**Important:** Do not use `./gradlew connectedDebugAndroidTest` — it uninstalls and reinstalls the app, wiping the database on the emulator. Use adb directly instead:
 
-# Or install and run via adb directly (useful if Gradle runner has issues)
+```bash
 ./gradlew assembleDebug assembleDebugAndroidTest
 adb install -r app/build/outputs/apk/debug/app-debug.apk
 adb install -r app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk

--- a/README.md
+++ b/README.md
@@ -29,7 +29,17 @@ This way, debug builds use debug OAuth and release builds use release OAuth auto
 
 ## Running tests
 
-Instrumentation tests require a running emulator or connected device.
+### Unit tests
+
+No emulator required:
+
+```bash
+./gradlew testDebugUnitTest
+```
+
+### Instrumented tests
+
+Requires a running emulator or connected device.
 
 **Important:** Do not use `./gradlew connectedDebugAndroidTest` — it uninstalls and reinstalls the app, wiping the database on the emulator. Use adb directly instead:
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ keytool -printcert -jarfile app.apk
 3. Update `app/src/{debug,release}/res/values/google_oauth_config.xml` with the debug and release client IDs respectively
 
 This way, debug builds use debug OAuth and release builds use release OAuth automatically.
+
+## Building
+
+```bash
+./gradlew assembleDebug
+```
+
+## Running tests
+
+Instrumentation tests require a running emulator or connected device.
+
+```bash
+# Run all instrumented tests via Gradle
+./gradlew connectedDebugAndroidTest
+
+# Or install and run via adb directly (useful if Gradle runner has issues)
+./gradlew assembleDebug assembleDebugAndroidTest
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+adb install -r app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+adb shell am instrument -w me.robwilliams.pack.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+To run a specific test class:
+```bash
+adb shell am instrument -w -e class me.robwilliams.pack.data.DatabaseMigrationTest me.robwilliams.pack.test/androidx.test.runner.AndroidJUnitRunner
+```

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ configurations.all {
 }
 
 dependencies {
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
             abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
@@ -53,6 +54,9 @@ configurations.all {
 }
 
 dependencies {
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.fragment:fragment:1.6.2'

--- a/app/src/androidTest/java/me/robwilliams/pack/data/DatabaseMigrationTest.java
+++ b/app/src/androidTest/java/me/robwilliams/pack/data/DatabaseMigrationTest.java
@@ -1,0 +1,342 @@
+package me.robwilliams.pack.data;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class DatabaseMigrationTest {
+
+    private static final String TEST_DB = "pack_migration_test";
+    private Context context;
+    private DatabaseHelper helper;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        context.deleteDatabase(TEST_DB);
+        helper = new DatabaseHelper(context);
+    }
+
+    @After
+    public void tearDown() {
+        context.deleteDatabase(TEST_DB);
+    }
+
+    private SQLiteDatabase createV1Database() {
+        SQLiteDatabase db = context.openOrCreateDatabase(TEST_DB, Context.MODE_PRIVATE, null);
+        db.execSQL("PRAGMA foreign_keys=ON");
+        db.execSQL("CREATE TABLE `list` (`_id` INTEGER PRIMARY KEY, `name` TEXT NOT NULL, `weight` INTEGER NOT NULL DEFAULT '0')");
+        db.execSQL("CREATE TABLE `item` (`_id` INTEGER PRIMARY KEY, `list_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `weight` INTEGER NOT NULL DEFAULT '0', FOREIGN KEY(list_id) REFERENCES list(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("CREATE TABLE `listset` (`_id` INTEGER PRIMARY KEY, `name` TEXT NOT NULL, `weight` INTEGER NOT NULL DEFAULT '0')");
+        db.execSQL("CREATE TABLE `listset_list` (`_id` INTEGER PRIMARY KEY, `listset_id` INTEGER NOT NULL, `list_id` INTEGER NOT NULL, FOREIGN KEY(listset_id) REFERENCES listset(_id) ON UPDATE CASCADE ON DELETE CASCADE, FOREIGN KEY(list_id) REFERENCES list(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("CREATE TABLE `trip` (`_id` INTEGER PRIMARY KEY, `name` TEXT NOT NULL, `timestamp` DATE DEFAULT (datetime('now','localtime')))");
+        db.execSQL("CREATE TABLE `trip_listset` (`_id` INTEGER PRIMARY KEY, `trip_id` INTEGER NOT NULL, `listset_id` INTEGER NOT NULL, FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE, FOREIGN KEY(listset_id) REFERENCES listset(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("CREATE TABLE `trip_item` (`_id` INTEGER PRIMARY KEY, `trip_id` INTEGER NOT NULL, `item_id` TEXT NOT NULL, `status` INTEGER NOT NULL, FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE, FOREIGN KEY(item_id) REFERENCES item(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        return db;
+    }
+
+    private SQLiteDatabase createV2Database() {
+        SQLiteDatabase db = createV1Database();
+        db.execSQL("CREATE TABLE IF NOT EXISTS `bag` (`_id` INTEGER PRIMARY KEY, `name` TEXT NOT NULL, `color` TEXT NOT NULL DEFAULT '#808080')");
+        db.execSQL("CREATE TABLE IF NOT EXISTS `trip_bag` (`_id` INTEGER PRIMARY KEY, `trip_id` INTEGER NOT NULL, `bag_id` INTEGER NOT NULL, FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE, FOREIGN KEY(bag_id) REFERENCES bag(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("ALTER TABLE item ADD COLUMN bag_hint_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
+        db.execSQL("ALTER TABLE trip_item ADD COLUMN quantity INTEGER NOT NULL DEFAULT 1");
+        db.execSQL("ALTER TABLE trip_item ADD COLUMN bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
+        return db;
+    }
+
+    private boolean columnExists(SQLiteDatabase db, String table, String column) {
+        Cursor cursor = db.rawQuery("PRAGMA table_info(" + table + ")", null);
+        boolean found = false;
+        while (cursor.moveToNext()) {
+            if (cursor.getString(cursor.getColumnIndexOrThrow("name")).equals(column)) {
+                found = true;
+                break;
+            }
+        }
+        cursor.close();
+        return found;
+    }
+
+    private boolean tableExists(SQLiteDatabase db, String table) {
+        Cursor cursor = db.rawQuery("SELECT name FROM sqlite_master WHERE type='table' AND name=?", new String[]{table});
+        boolean exists = cursor.getCount() > 0;
+        cursor.close();
+        return exists;
+    }
+
+    // --- V1 -> current: simulates restoring a v1 backup ---
+
+    @Test
+    public void migrateV1ToCurrent_createsNewTables() {
+        SQLiteDatabase db = createV1Database();
+        helper.onUpgrade(db, 1, 3);
+
+        assertTrue("bag table should exist", tableExists(db, "bag"));
+        assertTrue("trip_bag table should exist", tableExists(db, "trip_bag"));
+        db.close();
+    }
+
+    @Test
+    public void migrateV1ToCurrent_addsAllNewColumns() {
+        SQLiteDatabase db = createV1Database();
+        helper.onUpgrade(db, 1, 3);
+
+        assertTrue("item.bag_hint_id should exist", columnExists(db, "item", "bag_hint_id"));
+        assertTrue("trip_item.quantity should exist", columnExists(db, "trip_item", "quantity"));
+        assertTrue("trip_item.bag_id should exist", columnExists(db, "trip_item", "bag_id"));
+        assertTrue("list.default_bag_id should exist", columnExists(db, "list", "default_bag_id"));
+        db.close();
+    }
+
+    @Test
+    public void migrateV1ToCurrent_preservesExistingData() {
+        SQLiteDatabase db = createV1Database();
+
+        ContentValues listValues = new ContentValues();
+        listValues.put("name", "Clothes");
+        listValues.put("weight", 5);
+        long listId = db.insert("list", null, listValues);
+
+        ContentValues itemValues = new ContentValues();
+        itemValues.put("list_id", listId);
+        itemValues.put("name", "Socks");
+        itemValues.put("weight", 1);
+        db.insert("item", null, itemValues);
+
+        helper.onUpgrade(db, 1, 3);
+
+        Cursor cursor = db.rawQuery("SELECT name, weight FROM list WHERE _id=?", new String[]{String.valueOf(listId)});
+        assertTrue(cursor.moveToFirst());
+        assertEquals("Clothes", cursor.getString(0));
+        assertEquals(5, cursor.getInt(1));
+        cursor.close();
+
+        cursor = db.rawQuery("SELECT name, bag_hint_id FROM item WHERE list_id=?", new String[]{String.valueOf(listId)});
+        assertTrue(cursor.moveToFirst());
+        assertEquals("Socks", cursor.getString(0));
+        assertTrue("bag_hint_id should be null for existing items", cursor.isNull(1));
+        cursor.close();
+
+        db.close();
+    }
+
+    @Test
+    public void migrateV1ToCurrent_quantityDefaultsToOne() {
+        SQLiteDatabase db = createV1Database();
+
+        db.execSQL("INSERT INTO list (name) VALUES ('Test')");
+        db.execSQL("INSERT INTO item (list_id, name) VALUES (1, 'Shirt')");
+        db.execSQL("INSERT INTO trip (name) VALUES ('Trip1')");
+        db.execSQL("INSERT INTO trip_item (trip_id, item_id, status) VALUES (1, 1, 1)");
+
+        helper.onUpgrade(db, 1, 3);
+
+        Cursor cursor = db.rawQuery("SELECT quantity FROM trip_item WHERE _id=1", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(1, cursor.getInt(0));
+        cursor.close();
+
+        db.close();
+    }
+
+    @Test
+    public void migrateV1ToCurrent_fullDataSurvival() {
+        SQLiteDatabase db = createV1Database();
+
+        db.execSQL("INSERT INTO list (name, weight) VALUES ('Toiletries', 3)");
+        db.execSQL("INSERT INTO item (list_id, name, weight) VALUES (1, 'Toothbrush', 1)");
+        db.execSQL("INSERT INTO item (list_id, name, weight) VALUES (1, 'Soap', 2)");
+        db.execSQL("INSERT INTO trip (name) VALUES ('Beach Trip')");
+        db.execSQL("INSERT INTO trip_item (trip_id, item_id, status) VALUES (1, 1, 2)");
+
+        helper.onUpgrade(db, 1, 3);
+
+        for (String table : new String[]{"list", "item", "listset", "listset_list", "trip", "trip_listset", "trip_item", "bag", "trip_bag"}) {
+            assertTrue(table + " should exist", tableExists(db, table));
+        }
+
+        assertTrue(columnExists(db, "item", "bag_hint_id"));
+        assertTrue(columnExists(db, "trip_item", "quantity"));
+        assertTrue(columnExists(db, "trip_item", "bag_id"));
+        assertTrue(columnExists(db, "list", "default_bag_id"));
+
+        Cursor cursor = db.rawQuery("SELECT name FROM list", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals("Toiletries", cursor.getString(0));
+        cursor.close();
+
+        cursor = db.rawQuery("SELECT COUNT(*) FROM item WHERE list_id=1", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(2, cursor.getInt(0));
+        cursor.close();
+
+        cursor = db.rawQuery("SELECT status, quantity FROM trip_item WHERE trip_id=1 AND item_id=1", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(2, cursor.getInt(0));
+        assertEquals(1, cursor.getInt(1));
+        cursor.close();
+
+        db.close();
+    }
+
+    // --- V2 -> current: simulates a v2 database upgrading ---
+
+    @Test
+    public void migrateV2ToCurrent_addsDefaultBagIdColumn() {
+        SQLiteDatabase db = createV2Database();
+        helper.onUpgrade(db, 2, 3);
+
+        assertTrue("list.default_bag_id should exist", columnExists(db, "list", "default_bag_id"));
+        db.close();
+    }
+
+    @Test
+    public void migrateV2ToCurrent_defaultBagIdIsNullable() {
+        SQLiteDatabase db = createV2Database();
+        helper.onUpgrade(db, 2, 3);
+
+        db.execSQL("INSERT INTO list (name) VALUES ('Test')");
+        Cursor cursor = db.rawQuery("SELECT default_bag_id FROM list WHERE name='Test'", null);
+        assertTrue(cursor.moveToFirst());
+        assertTrue("default_bag_id should be null by default", cursor.isNull(0));
+        cursor.close();
+
+        db.close();
+    }
+
+    // --- Functional tests on fully migrated schema ---
+
+    @Test
+    public void migratedSchema_bagHintForeignKeyWorks() {
+        SQLiteDatabase db = createV1Database();
+        helper.onUpgrade(db, 1, 3);
+        db.execSQL("PRAGMA foreign_keys=ON");
+
+        db.execSQL("INSERT INTO bag (name, color) VALUES ('Backpack', '#4CAF50')");
+        db.execSQL("INSERT INTO list (name) VALUES ('Clothes')");
+        db.execSQL("INSERT INTO item (list_id, name, bag_hint_id) VALUES (1, 'Shirt', 1)");
+
+        Cursor cursor = db.rawQuery("SELECT bag_hint_id FROM item WHERE name='Shirt'", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(1, cursor.getInt(0));
+        cursor.close();
+
+        db.delete("bag", "_id=1", null);
+        cursor = db.rawQuery("SELECT bag_hint_id FROM item WHERE name='Shirt'", null);
+        assertTrue(cursor.moveToFirst());
+        assertTrue("bag_hint_id should be null after bag deletion", cursor.isNull(0));
+        cursor.close();
+
+        db.close();
+    }
+
+    @Test
+    public void migratedSchema_tripBagCascadeDelete() {
+        SQLiteDatabase db = createV1Database();
+        helper.onUpgrade(db, 1, 3);
+        db.execSQL("PRAGMA foreign_keys=ON");
+
+        db.execSQL("INSERT INTO bag (name, color) VALUES ('Carry-on', '#2196F3')");
+        db.execSQL("INSERT INTO trip (name) VALUES ('Flight')");
+        db.execSQL("INSERT INTO trip_bag (trip_id, bag_id) VALUES (1, 1)");
+
+        Cursor cursor = db.rawQuery("SELECT COUNT(*) FROM trip_bag WHERE trip_id=1", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(1, cursor.getInt(0));
+        cursor.close();
+
+        db.delete("trip", "_id=1", null);
+        cursor = db.rawQuery("SELECT COUNT(*) FROM trip_bag", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(0, cursor.getInt(0));
+        cursor.close();
+
+        db.close();
+    }
+
+    @Test
+    public void migratedSchema_quantityAndBagOnTripItem() {
+        SQLiteDatabase db = createV1Database();
+        helper.onUpgrade(db, 1, 3);
+
+        db.execSQL("INSERT INTO bag (name, color) VALUES ('Suitcase', '#F44336')");
+        db.execSQL("INSERT INTO list (name) VALUES ('Clothes')");
+        db.execSQL("INSERT INTO item (list_id, name) VALUES (1, 'Pants')");
+        db.execSQL("INSERT INTO trip (name) VALUES ('Vacation')");
+
+        ContentValues values = new ContentValues();
+        values.put("trip_id", 1);
+        values.put("item_id", 1);
+        values.put("status", 2);
+        values.put("quantity", 5);
+        values.put("bag_id", 1);
+        db.insert("trip_item", null, values);
+
+        Cursor cursor = db.rawQuery("SELECT quantity, bag_id FROM trip_item WHERE trip_id=1 AND item_id=1", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(5, cursor.getInt(0));
+        assertEquals(1, cursor.getInt(1));
+        cursor.close();
+
+        db.close();
+    }
+
+    @Test
+    public void migratedSchema_defaultBagIdOnList() {
+        SQLiteDatabase db = createV1Database();
+        helper.onUpgrade(db, 1, 3);
+        db.execSQL("PRAGMA foreign_keys=ON");
+
+        db.execSQL("INSERT INTO bag (name, color) VALUES ('Daypack', '#FF9800')");
+        db.execSQL("INSERT INTO list (name, default_bag_id) VALUES ('Hiking Gear', 1)");
+
+        Cursor cursor = db.rawQuery("SELECT default_bag_id FROM list WHERE name='Hiking Gear'", null);
+        assertTrue(cursor.moveToFirst());
+        assertEquals(1, cursor.getInt(0));
+        cursor.close();
+
+        db.delete("bag", "_id=1", null);
+        cursor = db.rawQuery("SELECT default_bag_id FROM list WHERE name='Hiking Gear'", null);
+        assertTrue(cursor.moveToFirst());
+        assertTrue("default_bag_id should be null after bag deletion", cursor.isNull(0));
+        cursor.close();
+
+        db.close();
+    }
+
+    // --- Fresh install (onCreate) test ---
+
+    @Test
+    public void freshInstall_allTablesAndColumnsExist() {
+        SQLiteDatabase db = context.openOrCreateDatabase(TEST_DB, Context.MODE_PRIVATE, null);
+        helper.onCreate(db);
+
+        for (String table : new String[]{"list", "item", "listset", "listset_list", "trip", "trip_listset", "trip_item", "bag", "trip_bag"}) {
+            assertTrue(table + " should exist", tableExists(db, table));
+        }
+
+        assertTrue(columnExists(db, "item", "bag_hint_id"));
+        assertTrue(columnExists(db, "trip_item", "quantity"));
+        assertTrue(columnExists(db, "trip_item", "bag_id"));
+        assertTrue(columnExists(db, "list", "default_bag_id"));
+        assertTrue(columnExists(db, "bag", "name"));
+        assertTrue(columnExists(db, "bag", "color"));
+        assertTrue(columnExists(db, "trip_bag", "trip_id"));
+        assertTrue(columnExists(db, "trip_bag", "bag_id"));
+
+        db.close();
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,14 @@
             android:name=".data.TripItemContentProvider"
             android:authorities="me.robwilliams.pack.trip_items.contentprovider" >
         </provider>
+        <provider
+            android:name=".data.BagContentProvider"
+            android:authorities="me.robwilliams.pack.bags.contentprovider" >
+        </provider>
+        <provider
+            android:name=".data.TripBagContentProvider"
+            android:authorities="me.robwilliams.pack.trip_bags.contentprovider" >
+        </provider>
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,14 @@
                 android:value="me.robwilliams.pack.SetOverviewActivity" />
         </activity>
         <activity
+            android:name=".BagManagementActivity"
+            android:label="@string/title_activity_bag_management"
+            android:parentActivityName=".MainActivity" >
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="me.robwilliams.pack.MainActivity" />
+        </activity>
+        <activity
             android:name=".TripOverviewActivity"
             android:label="@string/title_activity_trip_overview"
             android:parentActivityName=".MainActivity" >

--- a/app/src/main/java/me/robwilliams/pack/BagManagementActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/BagManagementActivity.java
@@ -32,9 +32,9 @@ public class BagManagementActivity extends AppCompatActivity
         implements LoaderManager.LoaderCallbacks<Cursor> {
 
     private static final String[] PRESET_COLORS = {
-            "#F44336", "#E91E63", "#9C27B0", "#2196F3",
-            "#00BCD4", "#009688", "#4CAF50", "#FF9800",
-            "#795548", "#9E9E9E", "#212121", "#FFEB3B"
+            "#EF9A9A", "#F48FB1", "#CE93D8", "#90CAF9",
+            "#80DEEA", "#80CBC4", "#A5D6A7", "#FFCC80",
+            "#BCAAA4", "#B0BEC5", "#78909C", "#FFD54F"
     };
 
     private SimpleCursorAdapter adapter;

--- a/app/src/main/java/me/robwilliams/pack/BagManagementActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/BagManagementActivity.java
@@ -1,0 +1,248 @@
+package me.robwilliams.pack;
+
+import android.app.AlertDialog;
+import android.app.LoaderManager;
+import android.content.ContentValues;
+import android.content.CursorLoader;
+import android.content.Loader;
+import android.database.Cursor;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.EditText;
+import android.widget.GridLayout;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.SimpleCursorAdapter;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import me.robwilliams.pack.data.BagContentProvider;
+
+public class BagManagementActivity extends AppCompatActivity
+        implements LoaderManager.LoaderCallbacks<Cursor> {
+
+    private static final String[] PRESET_COLORS = {
+            "#F44336", "#E91E63", "#9C27B0", "#2196F3",
+            "#00BCD4", "#009688", "#4CAF50", "#FF9800",
+            "#795548", "#9E9E9E", "#212121", "#FFEB3B"
+    };
+
+    private SimpleCursorAdapter adapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_bag_management);
+        fillData();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_bag_management, menu);
+        return true;
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        String[] projection = {"_id", "name", "color"};
+        return new CursorLoader(this, BagContentProvider.CONTENT_URI, projection, null, null, "name ASC");
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+        adapter.swapCursor(data);
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+        adapter.swapCursor(null);
+    }
+
+    private void fillData() {
+        getLoaderManager().initLoader(0, null, this);
+        adapter = new SimpleCursorAdapter(this,
+                android.R.layout.simple_list_item_1,
+                null,
+                new String[]{"name"},
+                new int[]{android.R.id.text1},
+                0);
+
+        adapter.setViewBinder(new SimpleCursorAdapter.ViewBinder() {
+            @Override
+            public boolean setViewValue(View view, Cursor cursor, int columnIndex) {
+                if (view.getId() == android.R.id.text1) {
+                    String name = cursor.getString(cursor.getColumnIndexOrThrow("name"));
+                    String color = cursor.getString(cursor.getColumnIndexOrThrow("color"));
+                    TextView textView = (TextView) view;
+                    textView.setText(name);
+                    textView.setCompoundDrawablePadding(16);
+                    GradientDrawable circle = new GradientDrawable();
+                    circle.setShape(GradientDrawable.OVAL);
+                    try {
+                        circle.setColor(Color.parseColor(color));
+                    } catch (Exception e) {
+                        circle.setColor(Color.GRAY);
+                    }
+                    int size = (int) (24 * view.getResources().getDisplayMetrics().density);
+                    circle.setBounds(0, 0, size, size);
+                    textView.setCompoundDrawables(circle, null, null, null);
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        ListView listView = (ListView) findViewById(R.id.bags_list);
+        listView.setAdapter(adapter);
+        listView.setEmptyView(findViewById(R.id.empty_bags));
+
+        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                Cursor cursor = (Cursor) adapter.getItem(position);
+                String name = cursor.getString(cursor.getColumnIndexOrThrow("name"));
+                String color = cursor.getString(cursor.getColumnIndexOrThrow("color"));
+                showEditBagDialog(id, name, color);
+            }
+        });
+
+        listView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+                Cursor cursor = (Cursor) adapter.getItem(position);
+                String name = cursor.getString(cursor.getColumnIndexOrThrow("name"));
+                showDeleteBagDialog(id, name);
+                return true;
+            }
+        });
+    }
+
+    public void showAddBagDialog(MenuItem item) {
+        showBagDialog(-1, "", PRESET_COLORS[6]);
+    }
+
+    private void showEditBagDialog(long bagId, String currentName, String currentColor) {
+        showBagDialog(bagId, currentName, currentColor);
+    }
+
+    private void showBagDialog(long bagId, String currentName, String currentColor) {
+        float density = getResources().getDisplayMetrics().density;
+        int dp16 = (int) (16 * density);
+        int dp8 = (int) (8 * density);
+        int dp40 = (int) (40 * density);
+
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(dp16, dp16, dp16, dp8);
+
+        TextView nameLabel = new TextView(this);
+        nameLabel.setText("Name");
+        nameLabel.setTextSize(12);
+        nameLabel.setTextColor(Color.GRAY);
+        layout.addView(nameLabel);
+
+        EditText nameInput = new EditText(this);
+        nameInput.setText(currentName);
+        nameInput.setTextSize(16);
+        layout.addView(nameInput);
+
+        TextView colorLabel = new TextView(this);
+        colorLabel.setText("Color");
+        colorLabel.setTextSize(12);
+        colorLabel.setTextColor(Color.GRAY);
+        colorLabel.setPadding(0, dp8, 0, dp8);
+        layout.addView(colorLabel);
+
+        final String[] selectedColor = {currentColor};
+
+        GridLayout colorGrid = new GridLayout(this);
+        colorGrid.setColumnCount(4);
+
+        for (String color : PRESET_COLORS) {
+            View swatch = new View(this);
+            GridLayout.LayoutParams params = new GridLayout.LayoutParams();
+            params.width = dp40;
+            params.height = dp40;
+            params.setMargins(dp8, dp8, dp8, dp8);
+            swatch.setLayoutParams(params);
+
+            GradientDrawable bg = new GradientDrawable();
+            bg.setShape(GradientDrawable.RECTANGLE);
+            bg.setCornerRadius(dp8);
+            bg.setColor(Color.parseColor(color));
+            if (color.equals(currentColor)) {
+                bg.setStroke((int) (3 * density), Color.BLACK);
+            }
+            swatch.setBackground(bg);
+
+            swatch.setOnClickListener(v -> {
+                selectedColor[0] = color;
+                for (int i = 0; i < colorGrid.getChildCount(); i++) {
+                    View child = colorGrid.getChildAt(i);
+                    GradientDrawable childBg = new GradientDrawable();
+                    childBg.setShape(GradientDrawable.RECTANGLE);
+                    childBg.setCornerRadius(dp8);
+                    childBg.setColor(Color.parseColor(PRESET_COLORS[i]));
+                    if (PRESET_COLORS[i].equals(color)) {
+                        childBg.setStroke((int) (3 * density), Color.BLACK);
+                    }
+                    child.setBackground(childBg);
+                }
+            });
+
+            colorGrid.addView(swatch);
+        }
+
+        layout.addView(colorGrid);
+
+        String title = bagId == -1 ? "Add Bag" : "Edit Bag";
+        AlertDialog.Builder builder = new AlertDialog.Builder(this)
+                .setTitle(title)
+                .setView(layout)
+                .setPositiveButton("Save", (dialog, which) -> {
+                    String name = nameInput.getText().toString().trim();
+                    if (name.isEmpty()) {
+                        Toast.makeText(this, "Name is required", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+                    ContentValues values = new ContentValues();
+                    values.put("name", name);
+                    values.put("color", selectedColor[0]);
+
+                    if (bagId == -1) {
+                        getContentResolver().insert(BagContentProvider.CONTENT_URI, values);
+                    } else {
+                        Uri uri = Uri.parse(BagContentProvider.CONTENT_URI + "/" + bagId);
+                        getContentResolver().update(uri, values, null, null);
+                    }
+                    getLoaderManager().restartLoader(0, null, this);
+                })
+                .setNegativeButton("Cancel", null);
+
+        builder.show();
+    }
+
+    private void showDeleteBagDialog(long bagId, String name) {
+        new AlertDialog.Builder(this)
+                .setTitle("Delete Bag")
+                .setMessage("Delete bag \"" + name + "\"? Items hinted to this bag will lose their hint.")
+                .setPositiveButton("Delete", (dialog, which) -> {
+                    Uri uri = Uri.parse(BagContentProvider.CONTENT_URI + "/" + bagId);
+                    getContentResolver().delete(uri, null, null);
+                    getLoaderManager().restartLoader(0, null, this);
+                    Toast.makeText(this, "Bag deleted", Toast.LENGTH_SHORT).show();
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/BagManagementActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/BagManagementActivity.java
@@ -215,6 +215,10 @@ public class BagManagementActivity extends AppCompatActivity
                         Toast.makeText(this, "Name is required", Toast.LENGTH_SHORT).show();
                         return;
                     }
+                    if (isBagNameTaken(name, bagId)) {
+                        Toast.makeText(this, "A bag named \"" + name + "\" already exists", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
                     ContentValues values = new ContentValues();
                     values.put("name", name);
                     values.put("color", selectedColor[0]);
@@ -230,6 +234,21 @@ public class BagManagementActivity extends AppCompatActivity
                 .setNegativeButton("Cancel", null);
 
         builder.show();
+    }
+
+    private boolean isBagNameTaken(String name, long excludeBagId) {
+        Cursor cursor = getContentResolver().query(BagContentProvider.CONTENT_URI,
+                new String[]{"_id"}, "name=?", new String[]{name}, null);
+        if (cursor == null) return false;
+        boolean taken = false;
+        while (cursor.moveToNext()) {
+            if (cursor.getLong(0) != excludeBagId) {
+                taken = true;
+                break;
+            }
+        }
+        cursor.close();
+        return taken;
     }
 
     private void showDeleteBagDialog(long bagId, String name) {

--- a/app/src/main/java/me/robwilliams/pack/BagPickerDialogHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/BagPickerDialogHelper.java
@@ -1,0 +1,82 @@
+package me.robwilliams.pack;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import java.util.List;
+
+import me.robwilliams.pack.data.Bag;
+
+public class BagPickerDialogHelper {
+
+    public interface OnBagSelectedListener {
+        void onBagSelected(Bag bag);
+        void onCancelled();
+    }
+
+    public static void show(Context context, String itemName, List<Bag> tripBags,
+                            int preselectedBagId, OnBagSelectedListener listener) {
+        if (tripBags == null || tripBags.isEmpty()) {
+            return;
+        }
+
+        int preselectedIndex = -1;
+        for (int i = 0; i < tripBags.size(); i++) {
+            if (tripBags.get(i).getId() == preselectedBagId) {
+                preselectedIndex = i;
+                break;
+            }
+        }
+
+        final int[] selectedIndex = {preselectedIndex >= 0 ? preselectedIndex : 0};
+
+        float density = context.getResources().getDisplayMetrics().density;
+        int dp12 = (int) (12 * density);
+        int dp8 = (int) (8 * density);
+
+        ArrayAdapter<Bag> adapter = new ArrayAdapter<Bag>(context, android.R.layout.simple_list_item_single_choice, tripBags) {
+            @Override
+            public View getView(int position, View convertView, ViewGroup parent) {
+                View view = super.getView(position, convertView, parent);
+                if (view instanceof TextView) {
+                    TextView tv = (TextView) view;
+                    Bag bag = tripBags.get(position);
+                    GradientDrawable circle = new GradientDrawable();
+                    circle.setShape(GradientDrawable.OVAL);
+                    try {
+                        circle.setColor(Color.parseColor(bag.getColor()));
+                    } catch (Exception e) {
+                        circle.setColor(Color.GRAY);
+                    }
+                    circle.setBounds(0, 0, dp12 * 2, dp12 * 2);
+                    tv.setCompoundDrawables(circle, null, null, null);
+                    tv.setCompoundDrawablePadding(dp8);
+                }
+                return view;
+            }
+        };
+
+        new AlertDialog.Builder(context)
+                .setTitle("Pack into: " + itemName)
+                .setSingleChoiceItems(adapter, selectedIndex[0], (dialog, which) -> {
+                    selectedIndex[0] = which;
+                })
+                .setPositiveButton("OK", (dialog, which) -> {
+                    if (selectedIndex[0] >= 0 && selectedIndex[0] < tripBags.size()) {
+                        listener.onBagSelected(tripBags.get(selectedIndex[0]));
+                    } else {
+                        listener.onCancelled();
+                    }
+                })
+                .setNegativeButton("Cancel", (dialog, which) -> listener.onCancelled())
+                .setOnCancelListener(dialog -> listener.onCancelled())
+                .show();
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/BagPickerDialogHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/BagPickerDialogHelper.java
@@ -10,6 +10,7 @@ import android.widget.ArrayAdapter;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import me.robwilliams.pack.data.Bag;
@@ -27,27 +28,28 @@ public class BagPickerDialogHelper {
             return;
         }
 
-        int preselectedIndex = -1;
-        for (int i = 0; i < tripBags.size(); i++) {
-            if (tripBags.get(i).getId() == preselectedBagId) {
-                preselectedIndex = i;
+        final List<Bag> orderedBags = new ArrayList<>(tripBags);
+        for (int i = 0; i < orderedBags.size(); i++) {
+            if (orderedBags.get(i).getId() == preselectedBagId) {
+                Bag preselected = orderedBags.remove(i);
+                orderedBags.add(0, preselected);
                 break;
             }
         }
 
-        final int[] selectedIndex = {preselectedIndex >= 0 ? preselectedIndex : 0};
+        final int[] selectedIndex = {0};
 
         float density = context.getResources().getDisplayMetrics().density;
         int dp12 = (int) (12 * density);
         int dp8 = (int) (8 * density);
 
-        ArrayAdapter<Bag> adapter = new ArrayAdapter<Bag>(context, android.R.layout.simple_list_item_single_choice, tripBags) {
+        ArrayAdapter<Bag> adapter = new ArrayAdapter<Bag>(context, android.R.layout.simple_list_item_single_choice, orderedBags) {
             @Override
             public View getView(int position, View convertView, ViewGroup parent) {
                 View view = super.getView(position, convertView, parent);
                 if (view instanceof TextView) {
                     TextView tv = (TextView) view;
-                    Bag bag = tripBags.get(position);
+                    Bag bag = orderedBags.get(position);
                     GradientDrawable circle = new GradientDrawable();
                     circle.setShape(GradientDrawable.OVAL);
                     try {
@@ -69,8 +71,8 @@ public class BagPickerDialogHelper {
                     selectedIndex[0] = which;
                 })
                 .setPositiveButton("OK", (dialog, which) -> {
-                    if (selectedIndex[0] >= 0 && selectedIndex[0] < tripBags.size()) {
-                        listener.onBagSelected(tripBags.get(selectedIndex[0]));
+                    if (selectedIndex[0] >= 0 && selectedIndex[0] < orderedBags.size()) {
+                        listener.onBagSelected(orderedBags.get(selectedIndex[0]));
                     } else {
                         listener.onCancelled();
                     }

--- a/app/src/main/java/me/robwilliams/pack/BagSelectionLogic.java
+++ b/app/src/main/java/me/robwilliams/pack/BagSelectionLogic.java
@@ -1,0 +1,15 @@
+package me.robwilliams.pack;
+
+public class BagSelectionLogic {
+
+    public static int resolvePreselectedBagId(int itemBagId, int bagHintId, int lastSelectedBagId) {
+        if (itemBagId > 0) return itemBagId;
+        if (bagHintId > 0) return bagHintId;
+        if (lastSelectedBagId > 0) return lastSelectedBagId;
+        return 0;
+    }
+
+    public static boolean shouldClearBagOnUncheck(int currentPageStatus, int statusPacked) {
+        return currentPageStatus == statusPacked;
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/ListDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/ListDetailActivity.java
@@ -1,13 +1,17 @@
 package me.robwilliams.pack;
 
+import android.app.AlertDialog;
 import android.app.LoaderManager;
 import android.content.ContentValues;
 import android.content.CursorLoader;
 import android.content.Intent;
 import android.content.Loader;
 import android.database.Cursor;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.Gravity;
 import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.Menu;
@@ -15,11 +19,20 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.ListView;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.ScrollView;
 import android.widget.SimpleCursorAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import me.robwilliams.pack.data.Bag;
+import me.robwilliams.pack.data.BagContentProvider;
 import me.robwilliams.pack.data.ItemContentProvider;
 import me.robwilliams.pack.data.ListContentProvider;
 
@@ -140,6 +153,7 @@ public class ListDetailActivity extends AppCompatActivity
             mListItemsView.setVisibility(View.VISIBLE);
             mEmptyItemsView.setVisibility(View.VISIBLE);
             findViewById(R.id.delete).setVisibility(View.VISIBLE);
+            findViewById(R.id.set_default_bag).setVisibility(View.VISIBLE);
             findViewById(R.id.add_list_item).setVisibility(View.VISIBLE);
 
             getLoaderManager().initLoader(0, null, this);
@@ -215,5 +229,131 @@ public class ListDetailActivity extends AppCompatActivity
         Intent intent = new Intent(this, ListItemDetailActivity.class);
         intent.putExtra(ListContentProvider.CONTENT_ID_TYPE, listId);
         startActivity(intent);
+    }
+
+    public void showSetDefaultBagDialog(View view) {
+        List<Bag> bags = new ArrayList<>();
+        Cursor cursor = getContentResolver().query(BagContentProvider.CONTENT_URI,
+                new String[]{"_id", "name", "color"}, null, null, "name ASC");
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                bags.add(new Bag(
+                        cursor.getInt(cursor.getColumnIndexOrThrow("_id")),
+                        cursor.getString(cursor.getColumnIndexOrThrow("name")),
+                        cursor.getString(cursor.getColumnIndexOrThrow("color"))
+                ));
+            }
+            cursor.close();
+        }
+
+        if (bags.isEmpty()) {
+            new AlertDialog.Builder(this)
+                    .setTitle("No Bags")
+                    .setMessage("No bags have been created yet. Create bags from the main screen first.")
+                    .setPositiveButton("OK", null)
+                    .show();
+            return;
+        }
+
+        float density = getResources().getDisplayMetrics().density;
+        int dp8 = (int) (8 * density);
+        int dp12 = (int) (12 * density);
+        int dp16 = (int) (16 * density);
+
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(dp16, dp16, dp16, dp8);
+
+        TextView description = new TextView(this);
+        description.setText("Select a default bag for this list. All items without an existing bag assignment will be updated. Items that already have a different bag will not be changed.\n\nNew items added to this list will also use this bag.");
+        description.setTextSize(14);
+        description.setPadding(0, 0, 0, dp16);
+        layout.addView(description);
+
+        RadioGroup radioGroup = new RadioGroup(this);
+        radioGroup.setOrientation(RadioGroup.VERTICAL);
+
+        for (int i = 0; i < bags.size(); i++) {
+            Bag bag = bags.get(i);
+
+            LinearLayout row = new LinearLayout(this);
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            row.setGravity(Gravity.CENTER_VERTICAL);
+            row.setPadding(0, dp8, 0, dp8);
+
+            RadioButton radio = new RadioButton(this);
+            radio.setId(View.generateViewId());
+            radio.setText("");
+
+            View dot = new View(this);
+            LinearLayout.LayoutParams dotParams = new LinearLayout.LayoutParams(dp12 * 2, dp12 * 2);
+            dotParams.setMargins(0, 0, dp12, 0);
+            dot.setLayoutParams(dotParams);
+            GradientDrawable circle = new GradientDrawable();
+            circle.setShape(GradientDrawable.OVAL);
+            try {
+                circle.setColor(Color.parseColor(bag.getColor()));
+            } catch (Exception e) {
+                circle.setColor(Color.GRAY);
+            }
+            dot.setBackground(circle);
+
+            TextView nameView = new TextView(this);
+            nameView.setText(bag.getName());
+            nameView.setTextSize(16);
+
+            row.addView(radio);
+            row.addView(dot);
+            row.addView(nameView);
+
+            final int radioId = radio.getId();
+            row.setOnClickListener(v -> radioGroup.check(radioId));
+
+            radioGroup.addView(row);
+        }
+
+        layout.addView(radioGroup);
+
+        ScrollView scrollView = new ScrollView(this);
+        scrollView.addView(layout);
+
+        final List<Bag> finalBags = bags;
+        new AlertDialog.Builder(this)
+                .setTitle("Set Default Bag")
+                .setView(scrollView)
+                .setPositiveButton("Apply", (dialog, which) -> {
+                    int checkedId = radioGroup.getCheckedRadioButtonId();
+                    if (checkedId == -1) return;
+
+                    int selectedIndex = -1;
+                    for (int i = 0; i < radioGroup.getChildCount(); i++) {
+                        LinearLayout row = (LinearLayout) radioGroup.getChildAt(i);
+                        RadioButton radio = (RadioButton) row.getChildAt(0);
+                        if (radio.getId() == checkedId) {
+                            selectedIndex = i;
+                            break;
+                        }
+                    }
+                    if (selectedIndex < 0 || selectedIndex >= finalBags.size()) return;
+
+                    Bag selectedBag = finalBags.get(selectedIndex);
+                    applyDefaultBag(selectedBag);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void applyDefaultBag(Bag bag) {
+        ContentValues listValues = new ContentValues();
+        listValues.put("default_bag_id", bag.getId());
+        getContentResolver().update(listUri, listValues, null, null);
+
+        ContentValues itemValues = new ContentValues();
+        itemValues.put("bag_hint_id", bag.getId());
+        int updated = getContentResolver().update(ItemContentProvider.CONTENT_URI, itemValues,
+                "list_id=" + listId + " AND bag_hint_id IS NULL", null);
+
+        Toast.makeText(this, "Default bag set to \"" + bag.getName() + "\". " +
+                updated + " item(s) updated.", Toast.LENGTH_LONG).show();
     }
 }

--- a/app/src/main/java/me/robwilliams/pack/ListDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/ListDetailActivity.java
@@ -21,8 +21,6 @@ import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ListView;
-import android.widget.RadioButton;
-import android.widget.RadioGroup;
 import android.widget.ScrollView;
 import android.widget.SimpleCursorAdapter;
 import android.widget.TextView;
@@ -270,20 +268,20 @@ public class ListDetailActivity extends AppCompatActivity
         description.setPadding(0, 0, 0, dp16);
         layout.addView(description);
 
-        RadioGroup radioGroup = new RadioGroup(this);
-        radioGroup.setOrientation(RadioGroup.VERTICAL);
+        final int[] selectedIndex = {-1};
 
+        LinearLayout bagList = new LinearLayout(this);
+        bagList.setOrientation(LinearLayout.VERTICAL);
+
+        final List<View> dotViews = new ArrayList<>();
         for (int i = 0; i < bags.size(); i++) {
+            final int index = i;
             Bag bag = bags.get(i);
 
             LinearLayout row = new LinearLayout(this);
             row.setOrientation(LinearLayout.HORIZONTAL);
             row.setGravity(Gravity.CENTER_VERTICAL);
-            row.setPadding(0, dp8, 0, dp8);
-
-            RadioButton radio = new RadioButton(this);
-            radio.setId(View.generateViewId());
-            radio.setText("");
+            row.setPadding(dp8, dp12, dp8, dp12);
 
             View dot = new View(this);
             LinearLayout.LayoutParams dotParams = new LinearLayout.LayoutParams(dp12 * 2, dp12 * 2);
@@ -297,22 +295,38 @@ public class ListDetailActivity extends AppCompatActivity
                 circle.setColor(Color.GRAY);
             }
             dot.setBackground(circle);
+            dotViews.add(dot);
 
             TextView nameView = new TextView(this);
             nameView.setText(bag.getName());
             nameView.setTextSize(16);
 
-            row.addView(radio);
             row.addView(dot);
             row.addView(nameView);
 
-            final int radioId = radio.getId();
-            row.setOnClickListener(v -> radioGroup.check(radioId));
+            row.setOnClickListener(v -> {
+                selectedIndex[0] = index;
+                for (int j = 0; j < dotViews.size(); j++) {
+                    View d = dotViews.get(j);
+                    GradientDrawable bg = new GradientDrawable();
+                    bg.setShape(GradientDrawable.OVAL);
+                    try {
+                        bg.setColor(Color.parseColor(bags.get(j).getColor()));
+                    } catch (Exception e) {
+                        bg.setColor(Color.GRAY);
+                    }
+                    if (j == index) {
+                        float dens = getResources().getDisplayMetrics().density;
+                        bg.setStroke((int)(3 * dens), Color.BLACK);
+                    }
+                    d.setBackground(bg);
+                }
+            });
 
-            radioGroup.addView(row);
+            bagList.addView(row);
         }
 
-        layout.addView(radioGroup);
+        layout.addView(bagList);
 
         ScrollView scrollView = new ScrollView(this);
         scrollView.addView(layout);
@@ -322,21 +336,8 @@ public class ListDetailActivity extends AppCompatActivity
                 .setTitle("Set Default Bag")
                 .setView(scrollView)
                 .setPositiveButton("Apply", (dialog, which) -> {
-                    int checkedId = radioGroup.getCheckedRadioButtonId();
-                    if (checkedId == -1) return;
-
-                    int selectedIndex = -1;
-                    for (int i = 0; i < radioGroup.getChildCount(); i++) {
-                        LinearLayout row = (LinearLayout) radioGroup.getChildAt(i);
-                        RadioButton radio = (RadioButton) row.getChildAt(0);
-                        if (radio.getId() == checkedId) {
-                            selectedIndex = i;
-                            break;
-                        }
-                    }
-                    if (selectedIndex < 0 || selectedIndex >= finalBags.size()) return;
-
-                    Bag selectedBag = finalBags.get(selectedIndex);
+                    if (selectedIndex[0] < 0 || selectedIndex[0] >= finalBags.size()) return;
+                    Bag selectedBag = finalBags.get(selectedIndex[0]);
                     applyDefaultBag(selectedBag);
                 })
                 .setNegativeButton("Cancel", null)

--- a/app/src/main/java/me/robwilliams/pack/ListDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/ListDetailActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.EditText;
@@ -65,8 +66,16 @@ public class ListDetailActivity extends AppCompatActivity
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
         return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/me/robwilliams/pack/ListItemDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/ListItemDetailActivity.java
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
@@ -61,6 +62,15 @@ public class ListItemDetailActivity extends AppCompatActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/me/robwilliams/pack/ListItemDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/ListItemDetailActivity.java
@@ -8,9 +8,16 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.View;
+import android.widget.ArrayAdapter;
 import android.widget.EditText;
+import android.widget.Spinner;
 import android.widget.Toast;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import me.robwilliams.pack.data.Bag;
+import me.robwilliams.pack.data.BagContentProvider;
 import me.robwilliams.pack.data.ItemContentProvider;
 import me.robwilliams.pack.data.ListContentProvider;
 
@@ -19,8 +26,11 @@ public class ListItemDetailActivity extends AppCompatActivity {
 
     private EditText mName;
     private EditText mWeight;
+    private Spinner mBagHintSpinner;
     private Uri listItemUri;
-    private int listId; // the ID for the List where this List Item should be added
+    private int listId;
+    private List<Bag> bags;
+    private int currentBagHintId = 0;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -29,14 +39,15 @@ public class ListItemDetailActivity extends AppCompatActivity {
 
         mName = (EditText) findViewById(R.id.name);
         mWeight = (EditText) findViewById(R.id.weight);
+        mBagHintSpinner = (Spinner) findViewById(R.id.bag_hint_spinner);
+
+        loadBags();
 
         Bundle extras = getIntent().getExtras();
 
-        // check from the saved Instance
         listItemUri = (savedInstanceState == null) ? null : (Uri) savedInstanceState
                 .getParcelable(ItemContentProvider.CONTENT_ITEM_TYPE);
 
-        // Or passed from the other activity
         if (extras != null) {
             listItemUri = extras.getParcelable(ItemContentProvider.CONTENT_ITEM_TYPE);
             listId = extras.getInt(ListContentProvider.CONTENT_ID_TYPE);
@@ -65,6 +76,53 @@ public class ListItemDetailActivity extends AppCompatActivity {
         saveState();
     }
 
+    private void loadBags() {
+        bags = new ArrayList<>();
+        Cursor cursor = getContentResolver().query(BagContentProvider.CONTENT_URI,
+                new String[]{"_id", "name", "color"}, null, null, "name ASC");
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                bags.add(new Bag(
+                        cursor.getInt(cursor.getColumnIndexOrThrow("_id")),
+                        cursor.getString(cursor.getColumnIndexOrThrow("name")),
+                        cursor.getString(cursor.getColumnIndexOrThrow("color"))
+                ));
+            }
+            cursor.close();
+        }
+
+        List<String> spinnerItems = new ArrayList<>();
+        spinnerItems.add("None");
+        for (Bag bag : bags) {
+            spinnerItems.add(bag.getName());
+        }
+
+        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(this,
+                android.R.layout.simple_spinner_item, spinnerItems);
+        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mBagHintSpinner.setAdapter(spinnerAdapter);
+    }
+
+    private void selectBagInSpinner(int bagHintId) {
+        if (bagHintId == 0) {
+            mBagHintSpinner.setSelection(0);
+            return;
+        }
+        for (int i = 0; i < bags.size(); i++) {
+            if (bags.get(i).getId() == bagHintId) {
+                mBagHintSpinner.setSelection(i + 1);
+                return;
+            }
+        }
+        mBagHintSpinner.setSelection(0);
+    }
+
+    private int getSelectedBagHintId() {
+        int pos = mBagHintSpinner.getSelectedItemPosition();
+        if (pos <= 0 || pos > bags.size()) return 0;
+        return bags.get(pos - 1).getId();
+    }
+
     private void saveState() {
         String name = mName.getText().toString();
         String weight = mWeight.getText().toString();
@@ -82,26 +140,34 @@ public class ListItemDetailActivity extends AppCompatActivity {
         values.put("weight", weightNumber);
         values.put("list_id", listId);
 
+        int bagHintId = getSelectedBagHintId();
+        if (bagHintId > 0) {
+            values.put("bag_hint_id", bagHintId);
+        } else {
+            values.putNull("bag_hint_id");
+        }
+
         if (listItemUri == null) {
-            // New list item
             listItemUri = getContentResolver().insert(ItemContentProvider.CONTENT_URI, values);
         } else {
-            // Update list item
             getContentResolver().update(listItemUri, values, null, null);
         }
     }
 
     private void fillData(Uri uri) {
-        String[] projection = {"_id", "name", "weight"};
+        String[] projection = {"_id", "name", "weight", "bag_hint_id"};
         Cursor cursor = getContentResolver().query(uri, projection, null, null, null);
         if (cursor != null) {
             cursor.moveToFirst();
             String listItemName = cursor.getString(cursor.getColumnIndexOrThrow("name"));
             mName.setText(listItemName);
             mWeight.setText(cursor.getString(cursor.getColumnIndexOrThrow("weight")));
+            currentBagHintId = cursor.isNull(cursor.getColumnIndexOrThrow("bag_hint_id")) ? 0 :
+                    cursor.getInt(cursor.getColumnIndexOrThrow("bag_hint_id"));
             cursor.close();
 
-            // Edit mode, so show delete button
+            selectBagInSpinner(currentBagHintId);
+
             setTitle("Editing Item: " + mName.getText());
             findViewById(R.id.delete).setVisibility(View.VISIBLE);
         }

--- a/app/src/main/java/me/robwilliams/pack/ListItemDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/ListItemDetailActivity.java
@@ -55,7 +55,26 @@ public class ListItemDetailActivity extends AppCompatActivity {
 
             if (listItemUri != null) {
                 fillData(listItemUri);
+            } else {
+                loadListDefaultBag();
             }
+        }
+    }
+
+    private void loadListDefaultBag() {
+        if (listId <= 0) return;
+        Uri listUri = Uri.parse(ListContentProvider.CONTENT_URI + "/" + listId);
+        Cursor cursor = getContentResolver().query(listUri,
+                new String[]{"_id", "default_bag_id"}, null, null, null);
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                int defaultBagId = cursor.isNull(cursor.getColumnIndexOrThrow("default_bag_id")) ? 0 :
+                        cursor.getInt(cursor.getColumnIndexOrThrow("default_bag_id"));
+                if (defaultBagId > 0) {
+                    selectBagInSpinner(defaultBagId);
+                }
+            }
+            cursor.close();
         }
     }
 

--- a/app/src/main/java/me/robwilliams/pack/MainActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/MainActivity.java
@@ -109,6 +109,11 @@ public class MainActivity extends AppCompatActivity {
         startActivity(intent);
     }
 
+    public void openBagsActivity(View view) {
+        Intent intent = new Intent(this, BagManagementActivity.class);
+        startActivity(intent);
+    }
+
     public void openCloudBackup(View view) {
         showCloudBackupDialog();
     }

--- a/app/src/main/java/me/robwilliams/pack/MainActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/MainActivity.java
@@ -37,6 +37,9 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().hide();
+        }
 
         driveService = new GoogleDriveService(this);
         setupActivityResultLaunchers();

--- a/app/src/main/java/me/robwilliams/pack/QuantityDialogHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/QuantityDialogHelper.java
@@ -1,0 +1,137 @@
+package me.robwilliams.pack;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.text.InputType;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.HorizontalScrollView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+public class QuantityDialogHelper {
+
+    private static final String PREFS_NAME = "quantity_prefs";
+    private static final String KEY_RECENT = "recent_quantities";
+    private static final int MAX_RECENT = 5;
+
+    public interface OnQuantitySetListener {
+        void onQuantitySet(int quantity);
+    }
+
+    public static void show(Context context, String itemName, int currentQuantity,
+                            OnQuantitySetListener listener) {
+        float density = context.getResources().getDisplayMetrics().density;
+        int dp16 = (int) (16 * density);
+        int dp8 = (int) (8 * density);
+        int dp48 = (int) (48 * density);
+
+        LinearLayout layout = new LinearLayout(context);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(dp16, dp16, dp16, dp8);
+
+        EditText input = new EditText(context);
+        input.setInputType(InputType.TYPE_CLASS_NUMBER);
+        input.setText(String.valueOf(currentQuantity));
+        input.selectAll();
+        input.setTextSize(18);
+        layout.addView(input);
+
+        List<Integer> recentQuantities = getRecentQuantities(context);
+        if (!recentQuantities.isEmpty()) {
+            TextView recentLabel = new TextView(context);
+            recentLabel.setText("Recent:");
+            recentLabel.setTextSize(12);
+            recentLabel.setTextColor(Color.GRAY);
+            recentLabel.setPadding(0, dp8, 0, dp8);
+            layout.addView(recentLabel);
+
+            HorizontalScrollView scrollView = new HorizontalScrollView(context);
+            LinearLayout buttonRow = new LinearLayout(context);
+            buttonRow.setOrientation(LinearLayout.HORIZONTAL);
+
+            for (int qty : recentQuantities) {
+                Button btn = new Button(context);
+                btn.setText(String.valueOf(qty));
+                btn.setMinimumWidth(dp48);
+                btn.setMinHeight(dp48);
+                LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT);
+                params.setMargins(0, 0, dp8, 0);
+                btn.setLayoutParams(params);
+                btn.setOnClickListener(v -> input.setText(String.valueOf(qty)));
+                buttonRow.addView(btn);
+            }
+
+            scrollView.addView(buttonRow);
+            layout.addView(scrollView);
+        }
+
+        new AlertDialog.Builder(context)
+                .setTitle("Quantity: " + itemName)
+                .setView(layout)
+                .setPositiveButton("OK", (dialog, which) -> {
+                    String text = input.getText().toString().trim();
+                    int quantity = 1;
+                    try {
+                        quantity = Integer.parseInt(text);
+                        if (quantity < 1) quantity = 1;
+                    } catch (NumberFormatException e) {
+                        // default to 1
+                    }
+                    saveRecentQuantity(context, quantity);
+                    listener.onQuantitySet(quantity);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private static List<Integer> getRecentQuantities(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String stored = prefs.getString(KEY_RECENT, "");
+        List<Integer> result = new ArrayList<>();
+        if (!stored.isEmpty()) {
+            for (String s : stored.split(",")) {
+                try {
+                    int val = Integer.parseInt(s.trim());
+                    if (val > 1) result.add(val);
+                } catch (NumberFormatException e) {
+                    // skip
+                }
+            }
+        }
+        return result;
+    }
+
+    private static void saveRecentQuantity(Context context, int quantity) {
+        if (quantity <= 1) return;
+        List<Integer> existing = getRecentQuantities(context);
+        LinkedHashSet<Integer> deduped = new LinkedHashSet<>();
+        deduped.add(quantity);
+        deduped.addAll(existing);
+
+        List<Integer> result = new ArrayList<>(deduped);
+        if (result.size() > MAX_RECENT) {
+            result = result.subList(0, MAX_RECENT);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < result.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(result.get(i));
+        }
+
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().putString(KEY_RECENT, sb.toString()).apply();
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/SetDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/SetDetailActivity.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.CheckedTextView;
@@ -25,6 +26,15 @@ import me.robwilliams.pack.data.SetContentProvider;
 
 
 public class SetDetailActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<Cursor> {
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
 
     private EditText mName;
     private EditText mWeight;

--- a/app/src/main/java/me/robwilliams/pack/TripBagSelectionDialogHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/TripBagSelectionDialogHelper.java
@@ -1,0 +1,115 @@
+package me.robwilliams.pack;
+
+import android.app.AlertDialog;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import me.robwilliams.pack.data.Bag;
+import me.robwilliams.pack.data.BagContentProvider;
+import me.robwilliams.pack.data.TripBagContentProvider;
+import me.robwilliams.pack.data.TripItemContentProvider;
+
+public class TripBagSelectionDialogHelper {
+
+    public interface OnBagsChangedListener {
+        void onBagsChanged(List<Bag> activeBags);
+    }
+
+    public static void show(Context context, int tripId, OnBagsChangedListener listener) {
+        List<Bag> allBags = new ArrayList<>();
+        Cursor cursor = context.getContentResolver().query(BagContentProvider.CONTENT_URI,
+                new String[]{"_id", "name", "color"}, null, null, "name ASC");
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                allBags.add(new Bag(
+                        cursor.getInt(cursor.getColumnIndexOrThrow("_id")),
+                        cursor.getString(cursor.getColumnIndexOrThrow("name")),
+                        cursor.getString(cursor.getColumnIndexOrThrow("color"))
+                ));
+            }
+            cursor.close();
+        }
+
+        if (allBags.isEmpty()) {
+            new AlertDialog.Builder(context)
+                    .setTitle("No Bags")
+                    .setMessage("No bags have been created yet. Create bags from the main screen first.")
+                    .setPositiveButton("OK", null)
+                    .show();
+            return;
+        }
+
+        Set<Integer> activeBagIds = new HashSet<>();
+        cursor = context.getContentResolver().query(TripBagContentProvider.CONTENT_URI,
+                new String[]{"_id", "bag_id"}, "trip_id=" + tripId, null, null);
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                activeBagIds.add(cursor.getInt(cursor.getColumnIndexOrThrow("bag_id")));
+            }
+            cursor.close();
+        }
+
+        String[] bagNames = new String[allBags.size()];
+        boolean[] checked = new boolean[allBags.size()];
+        for (int i = 0; i < allBags.size(); i++) {
+            bagNames[i] = allBags.get(i).getName();
+            checked[i] = activeBagIds.contains(allBags.get(i).getId());
+        }
+
+        final boolean[] originalChecked = checked.clone();
+
+        float density = context.getResources().getDisplayMetrics().density;
+        int dp12 = (int) (12 * density);
+
+        new AlertDialog.Builder(context)
+                .setTitle("Bags for this Trip")
+                .setMultiChoiceItems(bagNames, checked, (dialog, which, isChecked) -> {
+                    checked[which] = isChecked;
+                })
+                .setPositiveButton("OK", (dialog, which) -> {
+                    applyBagChanges(context, tripId, allBags, originalChecked, checked);
+                    List<Bag> newActiveBags = new ArrayList<>();
+                    for (int i = 0; i < allBags.size(); i++) {
+                        if (checked[i]) {
+                            newActiveBags.add(allBags.get(i));
+                        }
+                    }
+                    listener.onBagsChanged(newActiveBags);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private static void applyBagChanges(Context context, int tripId, List<Bag> allBags,
+                                          boolean[] originalChecked, boolean[] newChecked) {
+        for (int i = 0; i < allBags.size(); i++) {
+            int bagId = allBags.get(i).getId();
+            if (!originalChecked[i] && newChecked[i]) {
+                ContentValues values = new ContentValues();
+                values.put("trip_id", tripId);
+                values.put("bag_id", bagId);
+                context.getContentResolver().insert(TripBagContentProvider.CONTENT_URI, values);
+            } else if (originalChecked[i] && !newChecked[i]) {
+                ContentValues nullBag = new ContentValues();
+                nullBag.putNull("bag_id");
+                context.getContentResolver().update(TripItemContentProvider.CONTENT_URI, nullBag,
+                        "trip_id=" + tripId + " AND bag_id=" + bagId, null);
+                context.getContentResolver().delete(TripBagContentProvider.CONTENT_URI,
+                        "trip_id=" + tripId + " AND bag_id=" + bagId, null);
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/TripBagSelectionDialogHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/TripBagSelectionDialogHelper.java
@@ -6,10 +6,11 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
+import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import java.util.ArrayList;
@@ -62,10 +63,8 @@ public class TripBagSelectionDialogHelper {
             cursor.close();
         }
 
-        String[] bagNames = new String[allBags.size()];
-        boolean[] checked = new boolean[allBags.size()];
+        final boolean[] checked = new boolean[allBags.size()];
         for (int i = 0; i < allBags.size(); i++) {
-            bagNames[i] = allBags.get(i).getName();
             checked[i] = activeBagIds.contains(allBags.get(i).getId());
         }
 
@@ -73,12 +72,60 @@ public class TripBagSelectionDialogHelper {
 
         float density = context.getResources().getDisplayMetrics().density;
         int dp12 = (int) (12 * density);
+        int dp8 = (int) (8 * density);
+        int dp16 = (int) (16 * density);
+        int dp48 = (int) (48 * density);
+
+        LinearLayout listLayout = new LinearLayout(context);
+        listLayout.setOrientation(LinearLayout.VERTICAL);
+        listLayout.setPadding(dp16, dp8, dp16, dp8);
+
+        for (int i = 0; i < allBags.size(); i++) {
+            final int index = i;
+            Bag bag = allBags.get(i);
+
+            LinearLayout row = new LinearLayout(context);
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            row.setGravity(Gravity.CENTER_VERTICAL);
+            row.setMinimumHeight(dp48);
+            row.setPadding(0, dp8, 0, dp8);
+
+            CheckBox checkBox = new CheckBox(context);
+            checkBox.setChecked(checked[i]);
+            checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> checked[index] = isChecked);
+
+            View dot = new View(context);
+            LinearLayout.LayoutParams dotParams = new LinearLayout.LayoutParams(dp12 * 2, dp12 * 2);
+            dotParams.setMargins(dp8, 0, dp12, 0);
+            dot.setLayoutParams(dotParams);
+            GradientDrawable circle = new GradientDrawable();
+            circle.setShape(GradientDrawable.OVAL);
+            try {
+                circle.setColor(Color.parseColor(bag.getColor()));
+            } catch (Exception e) {
+                circle.setColor(Color.GRAY);
+            }
+            dot.setBackground(circle);
+
+            TextView nameView = new TextView(context);
+            nameView.setText(bag.getName());
+            nameView.setTextSize(16);
+
+            row.addView(checkBox);
+            row.addView(dot);
+            row.addView(nameView);
+
+            row.setOnClickListener(v -> checkBox.toggle());
+
+            listLayout.addView(row);
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.addView(listLayout);
 
         new AlertDialog.Builder(context)
                 .setTitle("Bags for this Trip")
-                .setMultiChoiceItems(bagNames, checked, (dialog, which, isChecked) -> {
-                    checked[which] = isChecked;
-                })
+                .setView(scrollView)
                 .setPositiveButton("OK", (dialog, which) -> {
                     applyBagChanges(context, tripId, allBags, originalChecked, checked);
                     List<Bag> newActiveBags = new ArrayList<>();

--- a/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
@@ -76,12 +76,17 @@ public class TripDetailActivity extends AppCompatActivity {
 
             // Now that we've loaded the Trip, load Trip Items
             SQLiteDatabase db = new DatabaseHelper(this).getReadableDatabase();
-            cursor = db.rawQuery("SELECT L.name as list_name, L.weight as list_weight, I._id as item_id, I.name as item_name, I.weight as item_weight, TI.status as status, LSL.listset_id as listset_id FROM trip T " +
+            cursor = db.rawQuery("SELECT L.name as list_name, L.weight as list_weight, " +
+                    "I._id as item_id, I.name as item_name, I.weight as item_weight, I.bag_hint_id, " +
+                    "TI.status as status, COALESCE(TI.quantity, 1) as quantity, TI.bag_id as bag_id, " +
+                    "B.name as bag_name, B.color as bag_color, " +
+                    "LSL.listset_id as listset_id FROM trip T " +
                     "INNER JOIN trip_listset TLS ON T._id=TLS.trip_id AND TLS.trip_id=" + tripId + " " +
                     "INNER JOIN listset_list LSL ON LSL.listset_id=TLS.listset_id " +
                     "INNER JOIN list L ON L._id=LSL.list_id " +
                     "INNER JOIN item I ON I.list_id=LSL.list_id " +
                     "LEFT JOIN trip_item TI ON TI.trip_id=TLS.trip_id AND TI.item_id=I._id " +
+                    "LEFT JOIN bag B ON B._id=TI.bag_id " +
                     "ORDER BY list_weight DESC, list_name ASC, item_weight DESC, item_name ASC", null);
 
             if (cursor != null) {
@@ -93,10 +98,18 @@ public class TripDetailActivity extends AppCompatActivity {
                     int listsetId = cursor.getInt(cursor.getColumnIndexOrThrow("listset_id"));
                     String itemName = cursor.getString(cursor.getColumnIndexOrThrow("item_name"));
                     int status = cursor.getInt(cursor.getColumnIndexOrThrow("status"));
+                    int quantity = cursor.getInt(cursor.getColumnIndexOrThrow("quantity"));
+                    int bagId = cursor.isNull(cursor.getColumnIndexOrThrow("bag_id")) ? 0 :
+                            cursor.getInt(cursor.getColumnIndexOrThrow("bag_id"));
+                    String bagName = cursor.getString(cursor.getColumnIndexOrThrow("bag_name"));
+                    String bagColor = cursor.getString(cursor.getColumnIndexOrThrow("bag_color"));
+                    int bagHintId = cursor.isNull(cursor.getColumnIndexOrThrow("bag_hint_id")) ? 0 :
+                            cursor.getInt(cursor.getColumnIndexOrThrow("bag_hint_id"));
                     if (status > maximumStatus) {
                         maximumStatus = status;
                     }
-                    tripItems.add(new TripItem(itemId, listsetId, listName, itemName, status));
+                    tripItems.add(new TripItem(itemId, listsetId, listName, itemName, status,
+                            quantity, bagId, bagName, bagColor, bagHintId));
                 }
 
                 // And now with the Trip Items, finish setting up UI
@@ -153,12 +166,8 @@ public class TripDetailActivity extends AppCompatActivity {
                     long tripId = Long.parseLong(tripUri.getLastPathSegment());
                     // Iterate through existing Trip's items to figure out Sets and Items we want
                     Set<Integer> setIds = new HashSet<>();
-                    Set<Integer> itemIds = new HashSet<>();
                     for (TripItem tripItem : tripItems) {
                         setIds.add(tripItem.getListsetId());
-                        if (tripItem.getStatus() >= AbstractPackingFragment.STATUS_SHOULD_PACK) {
-                            itemIds.add(tripItem.getItemId());
-                        }
                     }
                     // Next setup the join table relationship between new Trip and original Trip's sets
                     for (int listsetId : setIds) {
@@ -168,12 +177,15 @@ public class TripDetailActivity extends AppCompatActivity {
                         getContentResolver().insert(TripSetContentProvider.CONTENT_URI, values);
                     }
                     // Finally setup the Trip Item join table with a status of SHOULD_PACK
-                    for (int itemId : itemIds) {
-                        values = new ContentValues();
-                        values.put("trip_id", tripId);
-                        values.put("item_id", itemId);
-                        values.put("status", AbstractPackingFragment.STATUS_SHOULD_PACK);
-                        getContentResolver().insert(TripItemContentProvider.CONTENT_URI, values);
+                    for (TripItem ti : tripItems) {
+                        if (ti.getStatus() >= AbstractPackingFragment.STATUS_SHOULD_PACK) {
+                            values = new ContentValues();
+                            values.put("trip_id", tripId);
+                            values.put("item_id", ti.getItemId());
+                            values.put("status", AbstractPackingFragment.STATUS_SHOULD_PACK);
+                            values.put("quantity", ti.getQuantity());
+                            getContentResolver().insert(TripItemContentProvider.CONTENT_URI, values);
+                        }
                     }
                     // Then transition to the new Trip
                     Intent i = new Intent(that, TripDetailActivity.class);

--- a/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
@@ -19,10 +19,14 @@ import com.astuetz.PagerSlidingTabStrip;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import me.robwilliams.pack.adapter.TripDetailPagerAdapter;
+import me.robwilliams.pack.data.Bag;
+import me.robwilliams.pack.data.BagContentProvider;
 import me.robwilliams.pack.data.DatabaseHelper;
+import me.robwilliams.pack.data.TripBagContentProvider;
 import me.robwilliams.pack.data.TripContentProvider;
 import me.robwilliams.pack.data.TripItem;
 import me.robwilliams.pack.data.TripItemContentProvider;
@@ -36,6 +40,7 @@ public class TripDetailActivity extends AppCompatActivity {
     private Uri tripUri;
     private int tripId;
     private ArrayList<TripItem> tripItems;
+    private ArrayList<Bag> tripBags;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -112,10 +117,26 @@ public class TripDetailActivity extends AppCompatActivity {
                             quantity, bagId, bagName, bagColor, bagHintId));
                 }
 
+                // Load trip bags
+                tripBags = new ArrayList<>();
+                Cursor bagCursor = db.rawQuery(
+                        "SELECT B._id, B.name, B.color FROM trip_bag TB " +
+                        "INNER JOIN bag B ON B._id = TB.bag_id " +
+                        "WHERE TB.trip_id = " + tripId + " ORDER BY B.name ASC", null);
+                if (bagCursor != null) {
+                    while (bagCursor.moveToNext()) {
+                        tripBags.add(new Bag(
+                                bagCursor.getInt(0),
+                                bagCursor.getString(1),
+                                bagCursor.getString(2)));
+                    }
+                    bagCursor.close();
+                }
+
                 // And now with the Trip Items, finish setting up UI
                 setTitle("Trip: " + tripName);
                 viewPager = (ViewPager) findViewById(R.id.pager);
-                mAdapter = new TripDetailPagerAdapter(getSupportFragmentManager(), tripId, tripItems);
+                mAdapter = new TripDetailPagerAdapter(getSupportFragmentManager(), tripId, tripItems, tripBags);
                 viewPager.setAdapter(mAdapter);
 
                 PagerSlidingTabStrip tabs = (PagerSlidingTabStrip) findViewById(R.id.tabs);
@@ -187,6 +208,15 @@ public class TripDetailActivity extends AppCompatActivity {
                             getContentResolver().insert(TripItemContentProvider.CONTENT_URI, values);
                         }
                     }
+                    // Copy trip bags
+                    if (tripBags != null) {
+                        for (Bag bag : tripBags) {
+                            values = new ContentValues();
+                            values.put("trip_id", tripId);
+                            values.put("bag_id", bag.getId());
+                            getContentResolver().insert(TripBagContentProvider.CONTENT_URI, values);
+                        }
+                    }
                     // Then transition to the new Trip
                     Intent i = new Intent(that, TripDetailActivity.class);
                     tripUri = Uri.parse(TripContentProvider.CONTENT_URI + "/" + tripId);
@@ -199,6 +229,20 @@ public class TripDetailActivity extends AppCompatActivity {
                 }
             })
             .show();
+    }
+
+    public void showTripBagSelection(MenuItem item) {
+        TripBagSelectionDialogHelper.show(this, tripId,
+                new TripBagSelectionDialogHelper.OnBagsChangedListener() {
+                    @Override
+                    public void onBagsChanged(List<Bag> activeBags) {
+                        tripBags = new ArrayList<>(activeBags);
+                        mAdapter = new TripDetailPagerAdapter(getSupportFragmentManager(), tripId, tripItems, tripBags);
+                        viewPager.setAdapter(mAdapter);
+                        PagerSlidingTabStrip tabs = (PagerSlidingTabStrip) findViewById(R.id.tabs);
+                        tabs.setViewPager(viewPager);
+                    }
+                });
     }
 
     public void deleteTrip(MenuItem item) {

--- a/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
@@ -237,6 +237,17 @@ public class TripDetailActivity extends AppCompatActivity {
                     @Override
                     public void onBagsChanged(List<Bag> activeBags) {
                         tripBags = new ArrayList<>(activeBags);
+                        Set<Integer> activeBagIds = new HashSet<>();
+                        for (Bag bag : activeBags) {
+                            activeBagIds.add(bag.getId());
+                        }
+                        for (TripItem ti : tripItems) {
+                            if (ti.getBagId() > 0 && !activeBagIds.contains(ti.getBagId())) {
+                                ti.setBagId(0);
+                                ti.setBagName(null);
+                                ti.setBagColor(null);
+                            }
+                        }
                         mAdapter.updateTripBags(tripBags);
                     }
                 });

--- a/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
+++ b/app/src/main/java/me/robwilliams/pack/TripDetailActivity.java
@@ -237,10 +237,7 @@ public class TripDetailActivity extends AppCompatActivity {
                     @Override
                     public void onBagsChanged(List<Bag> activeBags) {
                         tripBags = new ArrayList<>(activeBags);
-                        mAdapter = new TripDetailPagerAdapter(getSupportFragmentManager(), tripId, tripItems, tripBags);
-                        viewPager.setAdapter(mAdapter);
-                        PagerSlidingTabStrip tabs = (PagerSlidingTabStrip) findViewById(R.id.tabs);
-                        tabs.setViewPager(viewPager);
+                        mAdapter.updateTripBags(tripBags);
                     }
                 });
     }

--- a/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import me.robwilliams.pack.QuantityDialogHelper;
 import me.robwilliams.pack.R;
 import me.robwilliams.pack.data.TripItem;
 import me.robwilliams.pack.data.TripItemContentProvider;
@@ -114,7 +115,11 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         final TextView textView = (TextView) itemLayout.getChildAt(0);
         final ImageView checkBox = (ImageView) itemLayout.getChildAt(1);
 
-        textView.setText(tripItem.getItemName());
+        String displayText = tripItem.getItemName();
+        if (tripItem.getQuantity() > 1) {
+            displayText += " x" + tripItem.getQuantity();
+        }
+        textView.setText(displayText);
 
         // Set checkbox state immediately without any animation
         boolean isChecked = tripItem.getStatus() >= currentPageStatus;
@@ -158,6 +163,34 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
                         listener.onDataChanged();
                     }
                 }
+            }
+        });
+
+        itemLayout.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                final int itemId = tripItem.getItemId();
+                QuantityDialogHelper.show(context, tripItem.getItemName(), tripItem.getQuantity(),
+                        new QuantityDialogHelper.OnQuantitySetListener() {
+                            @Override
+                            public void onQuantitySet(int quantity) {
+                                tripItemMap.get(itemId).setQuantity(quantity);
+                                ContentValues values = new ContentValues();
+                                values.put("quantity", quantity);
+                                if (tripItemMap.get(itemId).getStatus() == 0) {
+                                    values.put("item_id", itemId);
+                                    values.put("trip_id", tripId);
+                                    values.put("status", AbstractPackingFragment.STATUS_SHOULD_PACK);
+                                    tripItemMap.get(itemId).setStatus(AbstractPackingFragment.STATUS_SHOULD_PACK);
+                                    context.getContentResolver().insert(TripItemContentProvider.CONTENT_URI, values);
+                                } else {
+                                    context.getContentResolver().update(TripItemContentProvider.CONTENT_URI, values,
+                                            "item_id=" + itemId + " AND trip_id=" + tripId, null);
+                                }
+                                notifyDataSetChanged();
+                            }
+                        });
+                return true;
             }
         });
 

--- a/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
@@ -42,6 +42,7 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
     private int checkMarkDrawableResId;
     private WeakReference<OnDataChangeListener> dataChangeListenerRef;
     private List<Bag> tripBags;
+    private int lastSelectedBagId = 0;
 
     public PackingListExpandableAdapter(Context context, List<String> listNames,
                                         HashMap<String, List<TripItem>> listItems,
@@ -168,11 +169,14 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
                         && currentPageStatus >= AbstractPackingFragment.STATUS_PACKED;
 
                 if (needsBagSelection) {
-                    int preselectedBagId = tripItem.getBagId() > 0 ? tripItem.getBagId() : tripItem.getBagHintId();
+                    int preselectedBagId = tripItem.getBagHintId() > 0 ? tripItem.getBagHintId()
+                            : lastSelectedBagId > 0 ? lastSelectedBagId
+                            : 0;
                     BagPickerDialogHelper.show(context, tripItem.getItemName(), tripBags, preselectedBagId,
                             new BagPickerDialogHelper.OnBagSelectedListener() {
                                 @Override
                                 public void onBagSelected(Bag bag) {
+                                    lastSelectedBagId = bag.getId();
                                     performStatusUpdate(tripItem, itemId, newItemStatus, currentItemStatus,
                                             bag.getId(), bag.getName(), bag.getColor(), checkBox);
                                 }

--- a/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
@@ -169,7 +169,8 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
                         && currentPageStatus >= AbstractPackingFragment.STATUS_PACKED;
 
                 if (needsBagSelection) {
-                    int preselectedBagId = tripItem.getBagHintId() > 0 ? tripItem.getBagHintId()
+                    int preselectedBagId = tripItem.getBagId() > 0 ? tripItem.getBagId()
+                            : tripItem.getBagHintId() > 0 ? tripItem.getBagHintId()
                             : lastSelectedBagId > 0 ? lastSelectedBagId
                             : 0;
                     BagPickerDialogHelper.show(context, tripItem.getItemName(), tripBags, preselectedBagId,
@@ -237,7 +238,7 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         values.put("status", newItemStatus);
         if (bagId > 0) {
             values.put("bag_id", bagId);
-        } else if (!newCheckedState) {
+        } else if (!newCheckedState && currentPageStatus == AbstractPackingFragment.STATUS_PACKED) {
             values.putNull("bag_id");
         }
 
@@ -257,7 +258,7 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
             tripItemMap.get(itemId).setBagId(bagId);
             tripItemMap.get(itemId).setBagName(bagName);
             tripItemMap.get(itemId).setBagColor(bagColor);
-        } else if (!newCheckedState) {
+        } else if (!newCheckedState && currentPageStatus == AbstractPackingFragment.STATUS_PACKED) {
             tripItemMap.get(itemId).setBagId(0);
             tripItemMap.get(itemId).setBagName(null);
             tripItemMap.get(itemId).setBagColor(null);

--- a/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import me.robwilliams.pack.BagPickerDialogHelper;
+import me.robwilliams.pack.BagSelectionLogic;
 import me.robwilliams.pack.QuantityDialogHelper;
 import me.robwilliams.pack.R;
 import me.robwilliams.pack.data.Bag;
@@ -169,10 +170,8 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
                         && currentPageStatus >= AbstractPackingFragment.STATUS_PACKED;
 
                 if (needsBagSelection) {
-                    int preselectedBagId = tripItem.getBagId() > 0 ? tripItem.getBagId()
-                            : tripItem.getBagHintId() > 0 ? tripItem.getBagHintId()
-                            : lastSelectedBagId > 0 ? lastSelectedBagId
-                            : 0;
+                    int preselectedBagId = BagSelectionLogic.resolvePreselectedBagId(
+                            tripItem.getBagId(), tripItem.getBagHintId(), lastSelectedBagId);
                     BagPickerDialogHelper.show(context, tripItem.getItemName(), tripBags, preselectedBagId,
                             new BagPickerDialogHelper.OnBagSelectedListener() {
                                 @Override
@@ -238,7 +237,8 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         values.put("status", newItemStatus);
         if (bagId > 0) {
             values.put("bag_id", bagId);
-        } else if (!newCheckedState && currentPageStatus == AbstractPackingFragment.STATUS_PACKED) {
+        } else if (!newCheckedState && BagSelectionLogic.shouldClearBagOnUncheck(
+                currentPageStatus, AbstractPackingFragment.STATUS_PACKED)) {
             values.putNull("bag_id");
         }
 
@@ -258,7 +258,8 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
             tripItemMap.get(itemId).setBagId(bagId);
             tripItemMap.get(itemId).setBagName(bagName);
             tripItemMap.get(itemId).setBagColor(bagColor);
-        } else if (!newCheckedState && currentPageStatus == AbstractPackingFragment.STATUS_PACKED) {
+        } else if (!newCheckedState && BagSelectionLogic.shouldClearBagOnUncheck(
+                currentPageStatus, AbstractPackingFragment.STATUS_PACKED)) {
             tripItemMap.get(itemId).setBagId(0);
             tripItemMap.get(itemId).setBagName(null);
             tripItemMap.get(itemId).setBagColor(null);

--- a/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/PackingListExpandableAdapter.java
@@ -2,12 +2,13 @@ package me.robwilliams.pack.adapter;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
 import android.util.TypedValue;
-import android.view.LayoutInflater;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseExpandableListAdapter;
-import android.widget.CheckedTextView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -18,8 +19,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import me.robwilliams.pack.BagPickerDialogHelper;
 import me.robwilliams.pack.QuantityDialogHelper;
 import me.robwilliams.pack.R;
+import me.robwilliams.pack.data.Bag;
 import me.robwilliams.pack.data.TripItem;
 import me.robwilliams.pack.data.TripItemContentProvider;
 import me.robwilliams.pack.fragment.AbstractPackingFragment;
@@ -31,26 +34,28 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
     }
 
     private Context context;
-    private List<String> listNames; // Group headers (packing list names)
-    private HashMap<String, List<TripItem>> listItems; // Items grouped by list name
+    private List<String> listNames;
+    private HashMap<String, List<TripItem>> listItems;
     private Map<Integer, TripItem> tripItemMap;
     private int tripId;
     private int currentPageStatus;
     private int checkMarkDrawableResId;
     private WeakReference<OnDataChangeListener> dataChangeListenerRef;
+    private List<Bag> tripBags;
 
     public PackingListExpandableAdapter(Context context, List<String> listNames,
                                         HashMap<String, List<TripItem>> listItems,
                                         Map<Integer, TripItem> tripItemMap,
-                                        int tripId, int currentPageStatus) {
+                                        int tripId, int currentPageStatus,
+                                        List<Bag> tripBags) {
         this.context = context;
         this.listNames = listNames;
         this.listItems = listItems;
         this.tripItemMap = tripItemMap;
         this.tripId = tripId;
         this.currentPageStatus = currentPageStatus;
+        this.tripBags = tripBags != null ? tripBags : new ArrayList<>();
 
-        // Get system checkmark drawable
         TypedValue value = new TypedValue();
         context.getTheme().resolveAttribute(android.R.attr.listChoiceIndicatorMultiple, value, true);
         checkMarkDrawableResId = value.resourceId;
@@ -89,16 +94,25 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         final TripItem tripItem = (TripItem) getChild(groupPosition, childPosition);
 
         if (convertView == null) {
-            // Create a custom layout with LinearLayout containing TextView and ImageView
             LinearLayout layout = new LinearLayout(context);
             layout.setOrientation(LinearLayout.HORIZONTAL);
             layout.setPadding(60, 10, 10, 10);
             layout.setClickable(true);
+            layout.setGravity(Gravity.CENTER_VERTICAL);
 
             TextView textView = new TextView(context);
             textView.setLayoutParams(new LinearLayout.LayoutParams(
                 0, LinearLayout.LayoutParams.WRAP_CONTENT, 1.0f));
             textView.setTextSize(16);
+
+            View bagChip = new View(context);
+            float density = context.getResources().getDisplayMetrics().density;
+            int chipSize = (int) (12 * density);
+            LinearLayout.LayoutParams chipParams = new LinearLayout.LayoutParams(chipSize, chipSize);
+            chipParams.setMargins((int)(8 * density), 0, (int)(8 * density), 0);
+            chipParams.gravity = Gravity.CENTER_VERTICAL;
+            bagChip.setLayoutParams(chipParams);
+            bagChip.setVisibility(View.GONE);
 
             ImageView checkBox = new ImageView(context);
             checkBox.setLayoutParams(new LinearLayout.LayoutParams(
@@ -106,6 +120,7 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
             checkBox.setPadding(10, 0, 0, 0);
 
             layout.addView(textView);
+            layout.addView(bagChip);
             layout.addView(checkBox);
 
             convertView = layout;
@@ -113,7 +128,8 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
 
         final LinearLayout itemLayout = (LinearLayout) convertView;
         final TextView textView = (TextView) itemLayout.getChildAt(0);
-        final ImageView checkBox = (ImageView) itemLayout.getChildAt(1);
+        final View bagChip = itemLayout.getChildAt(1);
+        final ImageView checkBox = (ImageView) itemLayout.getChildAt(2);
 
         String displayText = tripItem.getItemName();
         if (tripItem.getQuantity() > 1) {
@@ -121,7 +137,21 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         }
         textView.setText(displayText);
 
-        // Set checkbox state immediately without any animation
+        // Bag chip
+        if (tripItem.getBagId() > 0 && tripItem.getBagColor() != null) {
+            GradientDrawable circle = new GradientDrawable();
+            circle.setShape(GradientDrawable.OVAL);
+            try {
+                circle.setColor(Color.parseColor(tripItem.getBagColor()));
+            } catch (Exception e) {
+                circle.setColor(Color.GRAY);
+            }
+            bagChip.setBackground(circle);
+            bagChip.setVisibility(View.VISIBLE);
+        } else {
+            bagChip.setVisibility(View.GONE);
+        }
+
         boolean isChecked = tripItem.getStatus() >= currentPageStatus;
         checkBox.setImageResource(isChecked ? R.drawable.ic_checkbox_checked : R.drawable.ic_checkbox_unchecked);
 
@@ -133,35 +163,29 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
                 int newItemStatus = currentItemStatus >= currentPageStatus ?
                     currentPageStatus - 1 : currentPageStatus;
 
-                // Update checkbox state immediately
-                boolean newCheckedState = newItemStatus >= currentPageStatus;
-                checkBox.setImageResource(newCheckedState ? R.drawable.ic_checkbox_checked : R.drawable.ic_checkbox_unchecked);
+                boolean isPacking = newItemStatus >= currentPageStatus;
+                boolean needsBagSelection = isPacking && !tripBags.isEmpty()
+                        && currentPageStatus >= AbstractPackingFragment.STATUS_PACKED;
 
-                ContentValues values = new ContentValues();
-                values.put("item_id", itemId);
-                values.put("trip_id", tripId);
-                values.put("status", newItemStatus);
+                if (needsBagSelection) {
+                    int preselectedBagId = tripItem.getBagId() > 0 ? tripItem.getBagId() : tripItem.getBagHintId();
+                    BagPickerDialogHelper.show(context, tripItem.getItemName(), tripBags, preselectedBagId,
+                            new BagPickerDialogHelper.OnBagSelectedListener() {
+                                @Override
+                                public void onBagSelected(Bag bag) {
+                                    performStatusUpdate(tripItem, itemId, newItemStatus, currentItemStatus,
+                                            bag.getId(), bag.getName(), bag.getColor(), checkBox);
+                                }
 
-                if (currentItemStatus == 0) {
-                    context.getContentResolver().insert(TripItemContentProvider.CONTENT_URI, values);
-                } else if (currentItemStatus == AbstractPackingFragment.STATUS_SHOULD_PACK &&
-                           currentPageStatus == AbstractPackingFragment.STATUS_SHOULD_PACK) {
-                    context.getContentResolver().delete(TripItemContentProvider.CONTENT_URI,
-                            "item_id=" + itemId + " AND trip_id=" + tripId, null);
+                                @Override
+                                public void onCancelled() {
+                                    // Do nothing — item stays at current status
+                                }
+                            });
                 } else {
-                    context.getContentResolver().update(TripItemContentProvider.CONTENT_URI, values,
-                            "item_id=" + itemId + " AND trip_id=" + tripId, null);
-                }
-
-                tripItemMap.get(itemId).setStatus(newItemStatus);
-
-                // For non-Should Pack views, we need to inform the fragment to refresh
-                // since the data structure needs to be rebuilt
-                if (currentPageStatus > AbstractPackingFragment.STATUS_SHOULD_PACK) {
-                    OnDataChangeListener listener = dataChangeListenerRef != null ? dataChangeListenerRef.get() : null;
-                    if (listener != null) {
-                        listener.onDataChanged();
-                    }
+                    int bagId = isPacking ? 0 : 0;
+                    performStatusUpdate(tripItem, itemId, newItemStatus, currentItemStatus,
+                            0, null, null, checkBox);
                 }
             }
         });
@@ -197,6 +221,52 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         return itemLayout;
     }
 
+    private void performStatusUpdate(TripItem tripItem, int itemId, int newItemStatus,
+                                     int currentItemStatus, int bagId, String bagName,
+                                     String bagColor, ImageView checkBox) {
+        boolean newCheckedState = newItemStatus >= currentPageStatus;
+        checkBox.setImageResource(newCheckedState ? R.drawable.ic_checkbox_checked : R.drawable.ic_checkbox_unchecked);
+
+        ContentValues values = new ContentValues();
+        values.put("item_id", itemId);
+        values.put("trip_id", tripId);
+        values.put("status", newItemStatus);
+        if (bagId > 0) {
+            values.put("bag_id", bagId);
+        } else if (!newCheckedState) {
+            values.putNull("bag_id");
+        }
+
+        if (currentItemStatus == 0) {
+            context.getContentResolver().insert(TripItemContentProvider.CONTENT_URI, values);
+        } else if (currentItemStatus == AbstractPackingFragment.STATUS_SHOULD_PACK &&
+                   currentPageStatus == AbstractPackingFragment.STATUS_SHOULD_PACK) {
+            context.getContentResolver().delete(TripItemContentProvider.CONTENT_URI,
+                    "item_id=" + itemId + " AND trip_id=" + tripId, null);
+        } else {
+            context.getContentResolver().update(TripItemContentProvider.CONTENT_URI, values,
+                    "item_id=" + itemId + " AND trip_id=" + tripId, null);
+        }
+
+        tripItemMap.get(itemId).setStatus(newItemStatus);
+        if (bagId > 0) {
+            tripItemMap.get(itemId).setBagId(bagId);
+            tripItemMap.get(itemId).setBagName(bagName);
+            tripItemMap.get(itemId).setBagColor(bagColor);
+        } else if (!newCheckedState) {
+            tripItemMap.get(itemId).setBagId(0);
+            tripItemMap.get(itemId).setBagName(null);
+            tripItemMap.get(itemId).setBagColor(null);
+        }
+
+        if (currentPageStatus > AbstractPackingFragment.STATUS_SHOULD_PACK) {
+            OnDataChangeListener listener = dataChangeListenerRef != null ? dataChangeListenerRef.get() : null;
+            if (listener != null) {
+                listener.onDataChanged();
+            }
+        }
+    }
+
     @Override
     public int getChildrenCount(int groupPosition) {
         return this.listItems.get(this.listNames.get(groupPosition)).size();
@@ -229,21 +299,17 @@ public class PackingListExpandableAdapter extends BaseExpandableListAdapter {
         TextView textView = (TextView) convertView;
         textView.setTextAppearance(context, android.R.style.TextAppearance_Large);
 
-        // Add expand/collapse indicator
         String indicator = isExpanded ? "− " : "+ ";
         textView.setText(indicator + listName);
 
         textView.setPadding(20, 15, 20, 15);
 
-        // Different background colors for expanded vs collapsed
         if (isExpanded) {
-            // Light pastel green background for expanded groups
-            textView.setBackgroundColor(0xFFE8F5E8); // Light pastel green
-            textView.setTextColor(0xFF2E7D32); // Darker green text
+            textView.setBackgroundColor(0xFFE8F5E8);
+            textView.setTextColor(0xFF2E7D32);
         } else {
-            // Light gray background with green text for collapsed groups
-            textView.setBackgroundColor(0xFFF5F5F5); // Light gray
-            textView.setTextColor(0xFF2E7D32); // Green text (same as expanded)
+            textView.setBackgroundColor(0xFFF5F5F5);
+            textView.setTextColor(0xFF2E7D32);
         }
 
         return textView;

--- a/app/src/main/java/me/robwilliams/pack/adapter/TripDetailPagerAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/TripDetailPagerAdapter.java
@@ -3,7 +3,7 @@ package me.robwilliams.pack.adapter;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.fragment.app.FragmentStatePagerAdapter;
 
 import java.util.ArrayList;
 
@@ -13,7 +13,7 @@ import me.robwilliams.pack.fragment.PackFragment;
 import me.robwilliams.pack.fragment.RepackFragment;
 import me.robwilliams.pack.fragment.ShouldPackFragment;
 
-public class TripDetailPagerAdapter extends FragmentPagerAdapter {
+public class TripDetailPagerAdapter extends FragmentStatePagerAdapter {
 
     private String[] pageTitles = {"Should Pack", "Pack", "Repack"};
     private int tripId;
@@ -25,6 +25,11 @@ public class TripDetailPagerAdapter extends FragmentPagerAdapter {
         this.tripId = tripId;
         this.tripItems = tripItems;
         this.tripBags = tripBags;
+    }
+
+    public void updateTripBags(ArrayList<Bag> tripBags) {
+        this.tripBags = tripBags;
+        notifyDataSetChanged();
     }
 
     @Override

--- a/app/src/main/java/me/robwilliams/pack/adapter/TripDetailPagerAdapter.java
+++ b/app/src/main/java/me/robwilliams/pack/adapter/TripDetailPagerAdapter.java
@@ -7,6 +7,7 @@ import androidx.fragment.app.FragmentPagerAdapter;
 
 import java.util.ArrayList;
 
+import me.robwilliams.pack.data.Bag;
 import me.robwilliams.pack.data.TripItem;
 import me.robwilliams.pack.fragment.PackFragment;
 import me.robwilliams.pack.fragment.RepackFragment;
@@ -17,11 +18,13 @@ public class TripDetailPagerAdapter extends FragmentPagerAdapter {
     private String[] pageTitles = {"Should Pack", "Pack", "Repack"};
     private int tripId;
     private ArrayList<TripItem> tripItems;
+    private ArrayList<Bag> tripBags;
 
-    public TripDetailPagerAdapter(FragmentManager fm, int tripId, ArrayList<TripItem> tripItems) {
+    public TripDetailPagerAdapter(FragmentManager fm, int tripId, ArrayList<TripItem> tripItems, ArrayList<Bag> tripBags) {
         super(fm);
         this.tripId = tripId;
         this.tripItems = tripItems;
+        this.tripBags = tripBags;
     }
 
     @Override
@@ -30,6 +33,7 @@ public class TripDetailPagerAdapter extends FragmentPagerAdapter {
         Bundle bundle = new Bundle();
         bundle.putInt("tripId", tripId);
         bundle.putParcelableArrayList("tripItems", tripItems);
+        bundle.putParcelableArrayList("tripBags", tripBags);
 
         switch (position) {
             case 0:
@@ -64,7 +68,6 @@ public class TripDetailPagerAdapter extends FragmentPagerAdapter {
 
     @Override
     public int getItemPosition(Object object) {
-        // This forces views to be recreated whenever the data set change notification comes.
         return POSITION_NONE;
     }
 }

--- a/app/src/main/java/me/robwilliams/pack/data/Bag.java
+++ b/app/src/main/java/me/robwilliams/pack/data/Bag.java
@@ -1,0 +1,52 @@
+package me.robwilliams.pack.data;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Bag implements Parcelable {
+    private int id;
+    private String name;
+    private String color;
+
+    public static final Parcelable.Creator<Bag> CREATOR = new Parcelable.Creator<Bag>() {
+        public Bag createFromParcel(Parcel in) {
+            return new Bag(in);
+        }
+
+        public Bag[] newArray(int size) {
+            return new Bag[size];
+        }
+    };
+
+    public Bag(int id, String name, String color) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+    }
+
+    public Bag(Parcel parcel) {
+        this.id = parcel.readInt();
+        this.name = parcel.readString();
+        this.color = parcel.readString();
+    }
+
+    public int getId() { return id; }
+    public String getName() { return name; }
+    public String getColor() { return color; }
+
+    public void setName(String name) { this.name = name; }
+    public void setColor(String color) { this.color = color; }
+
+    @Override
+    public String toString() { return name; }
+
+    @Override
+    public int describeContents() { return 0; }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(id);
+        dest.writeString(name);
+        dest.writeString(color);
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/data/BagContentProvider.java
+++ b/app/src/main/java/me/robwilliams/pack/data/BagContentProvider.java
@@ -1,0 +1,21 @@
+package me.robwilliams.pack.data;
+
+import android.net.Uri;
+
+public class BagContentProvider extends AbstractSqliteContentProvider {
+
+    public static Uri CONTENT_URI;
+    public static String CONTENT_ITEM_TYPE;
+
+    public BagContentProvider() {
+        super(/*tableName = */      "bag",
+              /*validColumns = */   new String[]{"_id", "name", "color"},
+              /*authority = */      "me.robwilliams.pack.bags.contentprovider",
+              /*basePath = */       "bags",
+              /*allItemsId = */     150,
+              /*singleItemId = */   160);
+
+        CONTENT_URI = getContentUri();
+        CONTENT_ITEM_TYPE = getContentItemType();
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/data/DatabaseHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/data/DatabaseHelper.java
@@ -20,7 +20,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL("CREATE TABLE `list` (" +
                 "  `_id` INTEGER PRIMARY KEY," +
                 "  `name` TEXT NOT NULL," +
-                "  `weight` INTEGER NOT NULL DEFAULT '0'" +
+                "  `weight` INTEGER NOT NULL DEFAULT '0'," +
+                "  `default_bag_id` INTEGER," +
+                "  FOREIGN KEY(default_bag_id) REFERENCES bag(_id) ON DELETE SET NULL" +
                 ");");
 
         db.execSQL("CREATE TABLE `bag` (" +
@@ -104,6 +106,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                     "  FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
                     "  FOREIGN KEY(bag_id) REFERENCES bag(_id) ON UPDATE CASCADE ON DELETE CASCADE" +
                     ");");
+            db.execSQL("ALTER TABLE list ADD COLUMN default_bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
             db.execSQL("ALTER TABLE item ADD COLUMN bag_hint_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
             db.execSQL("ALTER TABLE trip_item ADD COLUMN quantity INTEGER NOT NULL DEFAULT 1");
             db.execSQL("ALTER TABLE trip_item ADD COLUMN bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");

--- a/app/src/main/java/me/robwilliams/pack/data/DatabaseHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/data/DatabaseHelper.java
@@ -9,7 +9,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "pack";
 
     public DatabaseHelper(Context context) {
-        super(context, DATABASE_NAME, null, 2);
+        super(context, DATABASE_NAME, null, 3);
     }
 
     @Override
@@ -106,10 +106,12 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                     "  FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
                     "  FOREIGN KEY(bag_id) REFERENCES bag(_id) ON UPDATE CASCADE ON DELETE CASCADE" +
                     ");");
-            db.execSQL("ALTER TABLE list ADD COLUMN default_bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
             db.execSQL("ALTER TABLE item ADD COLUMN bag_hint_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
             db.execSQL("ALTER TABLE trip_item ADD COLUMN quantity INTEGER NOT NULL DEFAULT 1");
             db.execSQL("ALTER TABLE trip_item ADD COLUMN bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
+        }
+        if (oldVersion < 3) {
+            db.execSQL("ALTER TABLE list ADD COLUMN default_bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
         }
     }
 

--- a/app/src/main/java/me/robwilliams/pack/data/DatabaseHelper.java
+++ b/app/src/main/java/me/robwilliams/pack/data/DatabaseHelper.java
@@ -9,7 +9,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "pack";
 
     public DatabaseHelper(Context context) {
-        super(context, DATABASE_NAME, null, 1);
+        super(context, DATABASE_NAME, null, 2);
     }
 
     @Override
@@ -23,12 +23,20 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 "  `weight` INTEGER NOT NULL DEFAULT '0'" +
                 ");");
 
+        db.execSQL("CREATE TABLE `bag` (" +
+                "  `_id` INTEGER PRIMARY KEY," +
+                "  `name` TEXT NOT NULL," +
+                "  `color` TEXT NOT NULL DEFAULT '#808080'" +
+                ");");
+
         db.execSQL("CREATE TABLE `item` (" +
                 "  `_id` INTEGER PRIMARY KEY," +
                 "  `list_id` INTEGER NOT NULL," +
                 "  `name` TEXT NOT NULL," +
                 "  `weight` INTEGER NOT NULL DEFAULT '0'," +
-                "  FOREIGN KEY(list_id) REFERENCES list(_id) ON UPDATE CASCADE ON DELETE CASCADE" +
+                "  `bag_hint_id` INTEGER," +
+                "  FOREIGN KEY(list_id) REFERENCES list(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
+                "  FOREIGN KEY(bag_hint_id) REFERENCES bag(_id) ON DELETE SET NULL" +
                 ");");
 
         db.execSQL("CREATE TABLE `listset` (" +
@@ -64,28 +72,46 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 "  `trip_id` INTEGER NOT NULL," +
                 "  `item_id` TEXT NOT NULL," +
                 "  `status` INTEGER NOT NULL," +
+                "  `quantity` INTEGER NOT NULL DEFAULT 1," +
+                "  `bag_id` INTEGER," +
                 "  FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
-                "  FOREIGN KEY(item_id) REFERENCES item(_id) ON UPDATE CASCADE ON DELETE CASCADE" +
+                "  FOREIGN KEY(item_id) REFERENCES item(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
+                "  FOREIGN KEY(bag_id) REFERENCES bag(_id) ON DELETE SET NULL" +
+                ");");
+
+        db.execSQL("CREATE TABLE `trip_bag` (" +
+                "  `_id` INTEGER PRIMARY KEY," +
+                "  `trip_id` INTEGER NOT NULL," +
+                "  `bag_id` INTEGER NOT NULL," +
+                "  FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
+                "  FOREIGN KEY(bag_id) REFERENCES bag(_id) ON UPDATE CASCADE ON DELETE CASCADE" +
                 ");");
 
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        // Only one version for now, so just implement it as a DROP / recreate.
-        db.execSQL("DROP TABLE IF EXISTS `list`;");
-        db.execSQL("DROP TABLE IF EXISTS `item`;");
-        db.execSQL("DROP TABLE IF EXISTS `set`;");
-        db.execSQL("DROP TABLE IF EXISTS `set_list`;");
-        db.execSQL("DROP TABLE IF EXISTS `trip`;");
-        db.execSQL("DROP TABLE IF EXISTS `trip_list`;");
-        db.execSQL("DROP TABLE IF EXISTS `trip_item`;");
-        onCreate(db);
+        if (oldVersion < 2) {
+            db.execSQL("CREATE TABLE IF NOT EXISTS `bag` (" +
+                    "  `_id` INTEGER PRIMARY KEY," +
+                    "  `name` TEXT NOT NULL," +
+                    "  `color` TEXT NOT NULL DEFAULT '#808080'" +
+                    ");");
+            db.execSQL("CREATE TABLE IF NOT EXISTS `trip_bag` (" +
+                    "  `_id` INTEGER PRIMARY KEY," +
+                    "  `trip_id` INTEGER NOT NULL," +
+                    "  `bag_id` INTEGER NOT NULL," +
+                    "  FOREIGN KEY(trip_id) REFERENCES trip(_id) ON UPDATE CASCADE ON DELETE CASCADE," +
+                    "  FOREIGN KEY(bag_id) REFERENCES bag(_id) ON UPDATE CASCADE ON DELETE CASCADE" +
+                    ");");
+            db.execSQL("ALTER TABLE item ADD COLUMN bag_hint_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
+            db.execSQL("ALTER TABLE trip_item ADD COLUMN quantity INTEGER NOT NULL DEFAULT 1");
+            db.execSQL("ALTER TABLE trip_item ADD COLUMN bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL");
+        }
     }
 
     @Override
     public void onOpen(SQLiteDatabase db) {
-        // Must turn on foreign keys every time DB is opened or the foreign keys won't be enforced
         db.execSQL("PRAGMA foreign_keys=ON");
     }
 }

--- a/app/src/main/java/me/robwilliams/pack/data/ItemContentProvider.java
+++ b/app/src/main/java/me/robwilliams/pack/data/ItemContentProvider.java
@@ -9,7 +9,7 @@ public class ItemContentProvider extends AbstractSqliteContentProvider {
 
     public ItemContentProvider() {
         super(/*tableName = */      "item",
-              /*validColumns = */   new String[]{"_id", "list_id", "name", "weight"},
+              /*validColumns = */   new String[]{"_id", "list_id", "name", "weight", "bag_hint_id"},
               /*authority = */      "me.robwilliams.pack.list_items.contentprovider",
               /*basePath = */       "items",
               /*allItemsId = */     30,

--- a/app/src/main/java/me/robwilliams/pack/data/ListContentProvider.java
+++ b/app/src/main/java/me/robwilliams/pack/data/ListContentProvider.java
@@ -10,7 +10,7 @@ public class ListContentProvider extends AbstractSqliteContentProvider {
 
     public ListContentProvider() {
         super(/*tableName = */      "list",
-              /*validColumns = */   new String[]{"_id","name", "weight"},
+              /*validColumns = */   new String[]{"_id", "name", "weight", "default_bag_id"},
               /*authority = */      "me.robwilliams.pack.lists.contentprovider",
               /*basePath = */       "lists",
               /*allItemsId = */     10,

--- a/app/src/main/java/me/robwilliams/pack/data/TripBagContentProvider.java
+++ b/app/src/main/java/me/robwilliams/pack/data/TripBagContentProvider.java
@@ -1,0 +1,21 @@
+package me.robwilliams.pack.data;
+
+import android.net.Uri;
+
+public class TripBagContentProvider extends AbstractSqliteContentProvider {
+
+    public static Uri CONTENT_URI;
+    public static String CONTENT_ITEM_TYPE;
+
+    public TripBagContentProvider() {
+        super(/*tableName = */      "trip_bag",
+              /*validColumns = */   new String[]{"_id", "trip_id", "bag_id"},
+              /*authority = */      "me.robwilliams.pack.trip_bags.contentprovider",
+              /*basePath = */       "trip_bags",
+              /*allItemsId = */     170,
+              /*singleItemId = */   180);
+
+        CONTENT_URI = getContentUri();
+        CONTENT_ITEM_TYPE = getContentItemType();
+    }
+}

--- a/app/src/main/java/me/robwilliams/pack/data/TripItem.java
+++ b/app/src/main/java/me/robwilliams/pack/data/TripItem.java
@@ -9,6 +9,11 @@ public class TripItem implements Parcelable {
     final private String listName;
     final private String itemName;
     private int status;
+    private int quantity;
+    private int bagId;
+    private String bagName;
+    private String bagColor;
+    private int bagHintId;
 
     public static final Parcelable.Creator<TripItem> CREATOR = new Parcelable.Creator<TripItem>() {
         public TripItem createFromParcel(Parcel in) {
@@ -21,11 +26,21 @@ public class TripItem implements Parcelable {
     };
 
     public TripItem(int itemId, int listsetId, String listName, String itemName, int status) {
+        this(itemId, listsetId, listName, itemName, status, 1, 0, null, null, 0);
+    }
+
+    public TripItem(int itemId, int listsetId, String listName, String itemName, int status,
+                    int quantity, int bagId, String bagName, String bagColor, int bagHintId) {
         this.itemId = itemId;
         this.listsetId = listsetId;
         this.listName = listName;
         this.itemName = itemName;
         this.status = status;
+        this.quantity = quantity;
+        this.bagId = bagId;
+        this.bagName = bagName;
+        this.bagColor = bagColor;
+        this.bagHintId = bagHintId;
     }
 
     public TripItem(Parcel parcel) {
@@ -34,36 +49,32 @@ public class TripItem implements Parcelable {
         this.listName = parcel.readString();
         this.itemName = parcel.readString();
         this.status = parcel.readInt();
+        this.quantity = parcel.readInt();
+        this.bagId = parcel.readInt();
+        this.bagName = parcel.readString();
+        this.bagColor = parcel.readString();
+        this.bagHintId = parcel.readInt();
     }
 
-    public int getItemId() {
-        return itemId;
-    }
+    public int getItemId() { return itemId; }
+    public int getListsetId() { return listsetId; }
+    public String getListName() { return listName; }
+    public String getItemName() { return itemName; }
+    public int getStatus() { return status; }
+    public int getQuantity() { return quantity; }
+    public int getBagId() { return bagId; }
+    public String getBagName() { return bagName; }
+    public String getBagColor() { return bagColor; }
+    public int getBagHintId() { return bagHintId; }
 
-    public int getListsetId() {
-        return listsetId;
-    }
-
-    public String getListName() {
-        return listName;
-    }
-
-    public String getItemName() {
-        return itemName;
-    }
-
-    public int getStatus() {
-        return status;
-    }
-
-    public void setStatus(int status) {
-        this.status = status;
-    }
+    public void setStatus(int status) { this.status = status; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
+    public void setBagId(int bagId) { this.bagId = bagId; }
+    public void setBagName(String bagName) { this.bagName = bagName; }
+    public void setBagColor(String bagColor) { this.bagColor = bagColor; }
 
     @Override
-    public int describeContents() {
-        return 0;
-    }
+    public int describeContents() { return 0; }
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
@@ -72,5 +83,10 @@ public class TripItem implements Parcelable {
         dest.writeString(listName);
         dest.writeString(itemName);
         dest.writeInt(status);
+        dest.writeInt(quantity);
+        dest.writeInt(bagId);
+        dest.writeString(bagName);
+        dest.writeString(bagColor);
+        dest.writeInt(bagHintId);
     }
 }

--- a/app/src/main/java/me/robwilliams/pack/data/TripItemContentProvider.java
+++ b/app/src/main/java/me/robwilliams/pack/data/TripItemContentProvider.java
@@ -9,7 +9,7 @@ public class TripItemContentProvider extends AbstractSqliteContentProvider {
 
     public TripItemContentProvider() {
         super(/*tableName = */      "trip_item",
-              /*validColumns = */   new String[]{"_id", "trip_id", "item_id", "status"},
+              /*validColumns = */   new String[]{"_id", "trip_id", "item_id", "status", "quantity", "bag_id"},
               /*authority = */      "me.robwilliams.pack.trip_items.contentprovider",
               /*basePath = */       "trip_items",
               /*allItemsId = */     130,

--- a/app/src/main/java/me/robwilliams/pack/fragment/AbstractPackingFragment.java
+++ b/app/src/main/java/me/robwilliams/pack/fragment/AbstractPackingFragment.java
@@ -1,14 +1,18 @@
 package me.robwilliams.pack.fragment;
 
 import android.content.ContentValues;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckedTextView;
 import android.widget.ExpandableListView;
+import android.widget.HorizontalScrollView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -31,6 +35,8 @@ import me.robwilliams.pack.data.TripItemContentProvider;
 abstract public class AbstractPackingFragment extends Fragment implements PackingListExpandableAdapter.OnDataChangeListener {
     protected ExpandableListView expandableListView;
     protected PackingListExpandableAdapter expandableListAdapter;
+    protected HorizontalScrollView bagLegendScroll;
+    protected LinearLayout bagLegendContainer;
     protected int checkMarkDrawableResId;
 
     protected int tripId;
@@ -52,6 +58,8 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_packing, container, false);
         expandableListView = (ExpandableListView) rootView.findViewById(R.id.expandable_list_view);
+        bagLegendScroll = (HorizontalScrollView) rootView.findViewById(R.id.bag_legend_scroll);
+        bagLegendContainer = (LinearLayout) rootView.findViewById(R.id.bag_legend);
 
         // Look up resource id for built-in Android checkmark icon
         TypedValue value = new TypedValue();
@@ -75,8 +83,58 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
         expandedGroups = new HashSet<>();
 
         populateView();
+        populateBagLegend();
 
         return rootView;
+    }
+
+    protected void populateBagLegend() {
+        if (bagLegendScroll == null || bagLegendContainer == null) return;
+
+        if (tripBags == null || tripBags.isEmpty()) {
+            bagLegendScroll.setVisibility(View.GONE);
+            return;
+        }
+
+        bagLegendScroll.setVisibility(View.VISIBLE);
+        bagLegendContainer.removeAllViews();
+
+        float density = getResources().getDisplayMetrics().density;
+        int chipSize = (int) (10 * density);
+        int dp4 = (int) (4 * density);
+        int dp8 = (int) (8 * density);
+
+        for (Bag bag : tripBags) {
+            LinearLayout entry = new LinearLayout(getActivity());
+            entry.setOrientation(LinearLayout.HORIZONTAL);
+            entry.setGravity(Gravity.CENTER_VERTICAL);
+            LinearLayout.LayoutParams entryParams = new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+            entryParams.setMargins(0, 0, dp8 * 2, 0);
+            entry.setLayoutParams(entryParams);
+
+            View dot = new View(getActivity());
+            LinearLayout.LayoutParams dotParams = new LinearLayout.LayoutParams(chipSize, chipSize);
+            dotParams.setMargins(0, 0, dp4, 0);
+            dot.setLayoutParams(dotParams);
+            GradientDrawable circle = new GradientDrawable();
+            circle.setShape(GradientDrawable.OVAL);
+            try {
+                circle.setColor(Color.parseColor(bag.getColor()));
+            } catch (Exception e) {
+                circle.setColor(Color.GRAY);
+            }
+            dot.setBackground(circle);
+
+            TextView label = new TextView(getActivity());
+            label.setText(bag.getName());
+            label.setTextSize(12);
+            label.setTextColor(0xFF666666);
+
+            entry.addView(dot);
+            entry.addView(label);
+            bagLegendContainer.addView(entry);
+        }
     }
 
     protected void sortTripItems() {

--- a/app/src/main/java/me/robwilliams/pack/fragment/AbstractPackingFragment.java
+++ b/app/src/main/java/me/robwilliams/pack/fragment/AbstractPackingFragment.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import me.robwilliams.pack.R;
 import me.robwilliams.pack.adapter.PackingListExpandableAdapter;
+import me.robwilliams.pack.data.Bag;
 import me.robwilliams.pack.data.TripItem;
 import me.robwilliams.pack.data.TripItemContentProvider;
 
@@ -39,6 +40,7 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
     protected HashMap<String, List<TripItem>> groupedTripItems;
     protected List<String> listNames;
     protected Set<String> expandedGroups; // Track which groups are expanded
+    protected ArrayList<Bag> tripBags;
 
     public final static int STATUS_SHOULD_PACK = 1;
     public final static int STATUS_PACKED = 2;
@@ -60,6 +62,8 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
         Bundle arguments = getArguments();
         tripId = arguments.getInt("tripId");
         tripItems = arguments.getParcelableArrayList("tripItems");
+        tripBags = arguments.getParcelableArrayList("tripBags");
+        if (tripBags == null) tripBags = new ArrayList<>();
 
         // Put trip items in Map for easy access
         tripItemMap = new HashMap<>();
@@ -102,7 +106,8 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
             groupedTripItems,
             tripItemMap,
             tripId,
-            getCurrentPageStatus()
+            getCurrentPageStatus(),
+            tripBags
         );
 
         expandableListView.setAdapter(expandableListAdapter);

--- a/app/src/main/java/me/robwilliams/pack/fragment/AbstractPackingFragment.java
+++ b/app/src/main/java/me/robwilliams/pack/fragment/AbstractPackingFragment.java
@@ -46,6 +46,7 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
     protected HashMap<String, List<TripItem>> groupedTripItems;
     protected List<String> listNames;
     protected Set<String> expandedGroups; // Track which groups are expanded
+    protected boolean hasUserCollapsed = false;
     protected ArrayList<Bag> tripBags;
 
     public final static int STATUS_SHOULD_PACK = 1;
@@ -153,9 +154,6 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
             return;
         }
 
-        // Save current expansion states before rebuilding
-        saveExpansionStates();
-
         groupItemsByList();
 
         expandableListAdapter = new PackingListExpandableAdapter(
@@ -171,31 +169,46 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
         expandableListView.setAdapter(expandableListAdapter);
         expandableListAdapter.setOnDataChangeListener(this);
 
-        // Restore expansion states instead of expanding all groups
+        // Track user-initiated collapse/expand
+        expandableListView.setOnGroupCollapseListener(new ExpandableListView.OnGroupCollapseListener() {
+            @Override
+            public void onGroupCollapse(int groupPosition) {
+                hasUserCollapsed = true;
+                if (listNames != null && groupPosition < listNames.size()) {
+                    expandedGroups.remove(listNames.get(groupPosition));
+                }
+            }
+        });
+        expandableListView.setOnGroupExpandListener(new ExpandableListView.OnGroupExpandListener() {
+            @Override
+            public void onGroupExpand(int groupPosition) {
+                if (listNames != null && groupPosition < listNames.size()) {
+                    expandedGroups.add(listNames.get(groupPosition));
+                }
+            }
+        });
+
         restoreExpansionStates();
     }
 
-    private void saveExpansionStates() {
-        if (expandableListView != null && expandableListAdapter != null && listNames != null) {
-            expandedGroups.clear();
-            for (int i = 0; i < listNames.size(); i++) {
-                if (expandableListView.isGroupExpanded(i)) {
-                    expandedGroups.add(listNames.get(i));
-                }
-            }
-        }
-    }
-
     private void restoreExpansionStates() {
-        if (listNames == null) {
+        if (listNames == null || expandableListView == null) {
             return;
         }
 
-        // Handle first-time setup separately from restoration
-        if (expandedGroups.isEmpty()) {
-            performInitialExpansionSetup();
+        if (!hasUserCollapsed && expandedGroups.isEmpty()) {
+            // First time: expand all groups, deferred to after layout
+            expandableListView.post(new Runnable() {
+                @Override
+                public void run() {
+                    if (expandableListView != null && listNames != null) {
+                        for (int i = 0; i < listNames.size(); i++) {
+                            expandableListView.expandGroup(i);
+                        }
+                    }
+                }
+            });
         } else {
-            // Restore previously saved expansion states
             for (int i = 0; i < listNames.size(); i++) {
                 String groupName = listNames.get(i);
                 if (expandedGroups.contains(groupName)) {
@@ -203,26 +216,6 @@ abstract public class AbstractPackingFragment extends Fragment implements Packin
                 }
             }
         }
-    }
-
-    private void performInitialExpansionSetup() {
-        // Define initial expansion behavior for first-time setup
-        // Current behavior: expand all groups for better discoverability
-        for (int i = 0; i < listNames.size(); i++) {
-            expandableListView.expandGroup(i);
-            expandedGroups.add(listNames.get(i));
-        }
-
-        // Alternative behaviors (commented out):
-        //
-        // Expand only first group:
-        // if (!listNames.isEmpty()) {
-        //     expandableListView.expandGroup(0);
-        //     expandedGroups.add(listNames.get(0));
-        // }
-        //
-        // Expand no groups (all collapsed):
-        // (don't expand anything, leave expandedGroups empty)
     }
 
     private void groupItemsByList() {

--- a/app/src/main/res/drawable/ic_home_bags.xml
+++ b/app/src/main/res/drawable/ic_home_bags.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Suitcase body -->
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M17,6h-2V3c0,-0.55 -0.45,-1 -1,-1h-4c-0.55,0 -1,0.45 -1,1v3H7c-1.1,0 -2,0.9 -2,2v9c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V8c0,-1.1 -0.9,-2 -2,-2zM10,3h4v3h-4V3zM17,17H7V8h10v9z"/>
+    <!-- Left wheel -->
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M8.5,19.3a1.2,1.2 0,1 0,0 2.4a1.2,1.2 0,1 0,0 -2.4z"/>
+    <!-- Right wheel -->
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M15.5,19.3a1.2,1.2 0,1 0,0 2.4a1.2,1.2 0,1 0,0 -2.4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_cloud.xml
+++ b/app/src/main/res/drawable/ic_home_cloud.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_lists.xml
+++ b/app/src/main/res/drawable/ic_home_lists.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M3,13h2v-2H3v2zM3,17h2v-2H3v2zM3,9h2V7H3v2zM7,13h14v-2H7v2zM7,17h14v-2H7v2zM7,7v2h14V7H7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_more.xml
+++ b/app/src/main/res/drawable/ic_home_more.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#BDBDBD"
+        android:pathData="M6,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM18,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_sets.xml
+++ b/app/src/main/res/drawable/ic_home_sets.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M4,6H2v14c0,1.1 0.9,2 2,2h14v-2H4V6zM20,2H8c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2zM20,16H8V4h12v12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_trips.xml
+++ b/app/src/main/res/drawable/ic_home_trips.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1a8f0f"
+        android:pathData="M21,16v-2l-8,-5V3.5c0,-0.83 -0.67,-1.5 -1.5,-1.5S10,2.67 10,3.5V9l-8,5v2l8,-2.5V19l-2,1.5V22l3.5,-1 3.5,1v-1.5L13,19v-5.5l8,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/tile_background.xml
+++ b/app/src/main/res/drawable/tile_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#4075D975">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFF" />
+            <corners android:radius="12dp" />
+            <stroke android:width="1dp" android:color="#E0E0E0" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/activity_bag_management.xml
+++ b/app/src/main/res/layout/activity_bag_management.xml
@@ -1,0 +1,20 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    tools:context="me.robwilliams.pack.BagManagementActivity">
+
+    <ListView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/bags_list" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/no_bags"
+        android:id="@+id/empty_bags" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_list_detail.xml
+++ b/app/src/main/res/layout/activity_list_detail.xml
@@ -45,6 +45,14 @@
             android:onClick="deleteList"
             android:visibility="invisible" />
 
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/set_default_bag"
+            android:id="@+id/set_default_bag"
+            android:onClick="showSetDefaultBagDialog"
+            android:visibility="invisible" />
+
     </LinearLayout>
 
     <TextView

--- a/app/src/main/res/layout/activity_list_item_detail.xml
+++ b/app/src/main/res/layout/activity_list_item_detail.xml
@@ -23,6 +23,15 @@
         android:inputType="number"
         android:id="@+id/weight" />
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/label_default_bag" />
+    <Spinner
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/bag_hint_spinner" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,6 +49,18 @@
         android:layout_weight="1" />
 
     <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Bags"
+        android:id="@+id/bagsButton"
+        android:onClick="openBagsActivity" />
+
+    <View
+        android:layout_width="1dp"
+        android:layout_height="0dip"
+        android:layout_weight="1" />
+
+    <Button
         android:id="@+id/cloudBackupButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -39,9 +39,9 @@
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Trips"
-        android:id="@+id/tripsButton"
-        android:onClick="openTripsActivity" />
+        android:text="Bags"
+        android:id="@+id/bagsButton"
+        android:onClick="openBagsActivity" />
 
     <View
         android:layout_width="1dp"
@@ -51,9 +51,9 @@
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Bags"
-        android:id="@+id/bagsButton"
-        android:onClick="openBagsActivity" />
+        android:text="Trips"
+        android:id="@+id/tripsButton"
+        android:onClick="openTripsActivity" />
 
     <View
         android:layout_width="1dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,74 +1,208 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="me.robwilliams.pack.MainActivity"
     android:orientation="vertical"
-    android:padding="16dp"
-    android:focusable="true"
-    android:focusableInTouchMode="true">
+    android:gravity="center"
+    android:padding="24dp"
+    android:background="#FAFAFA">
 
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dip"
-        android:layout_weight="1" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textSize="32sp"
+        android:textColor="@color/primary_dark"
+        android:textStyle="bold"
+        android:layout_marginBottom="32dp" />
 
-    <Button
+    <GridLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/title_activity_list_overview"
-        android:id="@+id/listsButton"
-        android:onClick="openListsActivity" />
+        android:columnCount="3"
+        android:rowCount="2"
+        android:alignmentMode="alignBounds"
+        android:useDefaultMargins="false">
 
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dip"
-        android:layout_weight="1" />
+        <!-- Row 1 -->
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/title_activity_set_overview"
-        android:id="@+id/setsButton"
-        android:onClick="openSetsActivity"/>
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            android:layout_margin="6dp"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="20dp"
+            android:background="@drawable/tile_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:onClick="openListsActivity">
 
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dip"
-        android:layout_weight="1" />
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_home_lists"
+                android:layout_marginBottom="8dp" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Bags"
-        android:id="@+id/bagsButton"
-        android:onClick="openBagsActivity" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/title_activity_list_overview"
+                android:textSize="13sp"
+                android:textColor="#424242"
+                android:gravity="center" />
+        </LinearLayout>
 
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dip"
-        android:layout_weight="1" />
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            android:layout_margin="6dp"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="20dp"
+            android:background="@drawable/tile_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:onClick="openSetsActivity">
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Trips"
-        android:id="@+id/tripsButton"
-        android:onClick="openTripsActivity" />
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_home_sets"
+                android:layout_marginBottom="8dp" />
 
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dip"
-        android:layout_weight="1" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/title_activity_set_overview"
+                android:textSize="13sp"
+                android:textColor="#424242"
+                android:gravity="center" />
+        </LinearLayout>
 
-    <Button
-        android:id="@+id/cloudBackupButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:onClick="openCloudBackup"
-        android:text="Cloud Backup" />
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            android:layout_margin="6dp"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="20dp"
+            android:background="@drawable/tile_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:onClick="openBagsActivity">
 
-    <View
-        android:layout_width="1dp"
-        android:layout_height="0dip"
-        android:layout_weight="1" />
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_home_bags"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/title_activity_bag_management"
+                android:textSize="13sp"
+                android:textColor="#424242"
+                android:gravity="center" />
+        </LinearLayout>
+
+        <!-- Row 2 -->
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            android:layout_margin="6dp"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="20dp"
+            android:background="@drawable/tile_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:onClick="openTripsActivity">
+
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_home_trips"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Trips"
+                android:textSize="13sp"
+                android:textColor="#424242"
+                android:gravity="center" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            android:layout_margin="6dp"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="20dp"
+            android:background="@drawable/tile_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:onClick="openCloudBackup">
+
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_home_cloud"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cloud Backup"
+                android:textSize="13sp"
+                android:textColor="#424242"
+                android:gravity="center" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            android:layout_margin="6dp"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="20dp"
+            android:background="@drawable/tile_background"
+            android:clickable="false"
+            android:focusable="false"
+            android:alpha="0.4">
+
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_home_more"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Future"
+                android:textSize="13sp"
+                android:textColor="#9E9E9E"
+                android:gravity="center" />
+        </LinearLayout>
+
+    </GridLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_packing.xml
+++ b/app/src/main/res/layout/fragment_packing.xml
@@ -1,14 +1,40 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" tools:context="me.robwilliams.pack.fragment.ShouldPackFragment">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="me.robwilliams.pack.fragment.ShouldPackFragment">
+
+    <HorizontalScrollView
+        android:id="@+id/bag_legend_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:requiresFadingEdge="horizontal"
+        android:fadingEdgeLength="24dp"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:id="@+id/bag_legend"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="12dp"
+            android:paddingRight="12dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
+            android:background="#FFF5F5F5" />
+
+    </HorizontalScrollView>
 
     <ExpandableListView
         android:id="@+id/expandable_list_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:groupIndicator="@null"
         android:childDivider="@android:color/transparent"
         android:divider="@android:color/transparent"
         android:dividerHeight="2dp" />
 
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/menu_bag_management.xml
+++ b/app/src/main/res/menu/menu_bag_management.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="me.robwilliams.pack.BagManagementActivity">
+
+    <item android:id="@+id/action_add_bag"
+        android:title="@string/action_add_bag"
+        android:onClick="showAddBagDialog"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/menu/menu_trip_detail.xml
+++ b/app/src/main/res/menu/menu_trip_detail.xml
@@ -2,6 +2,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="me.robwilliams.pack.TripDetailActivity">
+    <item android:id="@+id/action_manage_bags" android:title="@string/action_manage_trip_bags"
+        android:orderInCategory="50" app:showAsAction="ifRoom"
+        android:onClick="showTripBagSelection" />
     <item android:id="@+id/action_copy_trip" android:title="@string/action_copy_trip"
         android:orderInCategory="100" app:showAsAction="never"
         android:onClick="showCopyTripDialog" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="title_activity_trip_detail">Trip Detail</string>
     <string name="action_copy_trip">Copy Trip</string>
     <string name="action_delete_trip">Delete Trip</string>
+    <string name="action_manage_trip_bags">Bags</string>
 
     <!-- Strings for Bag Management Activity -->
     <string name="title_activity_bag_management">Bags</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="label_name">Name</string>
     <string name="label_weight">Weight</string>
     <string name="label_default_bag">Default Bag</string>
+    <string name="set_default_bag">Set Default Bag</string>
 
     <!-- Google Drive API Configuration is in build variant specific files:
          app/src/debug/res/values/google_oauth_config.xml

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,9 +41,15 @@
     <string name="action_copy_trip">Copy Trip</string>
     <string name="action_delete_trip">Delete Trip</string>
 
+    <!-- Strings for Bag Management Activity -->
+    <string name="title_activity_bag_management">Bags</string>
+    <string name="action_add_bag">Add Bag</string>
+    <string name="no_bags">No bags defined yet. Add one to start tracking which bag items go in.</string>
+
     <!-- Shared Strings used throughout application -->
     <string name="label_name">Name</string>
     <string name="label_weight">Weight</string>
+    <string name="label_default_bag">Default Bag</string>
 
     <!-- Google Drive API Configuration is in build variant specific files:
          app/src/debug/res/values/google_oauth_config.xml

--- a/app/src/test/java/me/robwilliams/pack/BagSelectionLogicTest.java
+++ b/app/src/test/java/me/robwilliams/pack/BagSelectionLogicTest.java
@@ -1,0 +1,73 @@
+package me.robwilliams.pack;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class BagSelectionLogicTest {
+
+    // --- resolvePreselectedBagId ---
+
+    @Test
+    public void preselect_itemBagTakesPriority() {
+        assertEquals(10, BagSelectionLogic.resolvePreselectedBagId(10, 20, 30));
+    }
+
+    @Test
+    public void preselect_bagHintWhenNoItemBag() {
+        assertEquals(20, BagSelectionLogic.resolvePreselectedBagId(0, 20, 30));
+    }
+
+    @Test
+    public void preselect_lastSelectedWhenNoItemBagOrHint() {
+        assertEquals(30, BagSelectionLogic.resolvePreselectedBagId(0, 0, 30));
+    }
+
+    @Test
+    public void preselect_zeroWhenNothingSet() {
+        assertEquals(0, BagSelectionLogic.resolvePreselectedBagId(0, 0, 0));
+    }
+
+    @Test
+    public void preselect_itemBagOverridesAll() {
+        assertEquals(5, BagSelectionLogic.resolvePreselectedBagId(5, 10, 15));
+    }
+
+    @Test
+    public void preselect_hintOverridesLastSelected() {
+        assertEquals(10, BagSelectionLogic.resolvePreselectedBagId(0, 10, 15));
+    }
+
+    @Test
+    public void preselect_repackUsesItemBag() {
+        // Repack scenario: item was packed into bag 7, hint is 3, last selected is 5
+        assertEquals(7, BagSelectionLogic.resolvePreselectedBagId(7, 3, 5));
+    }
+
+    @Test
+    public void preselect_packWithOnlyHint() {
+        // Pack scenario: no current bag, hint is set
+        assertEquals(3, BagSelectionLogic.resolvePreselectedBagId(0, 3, 0));
+    }
+
+    // --- shouldClearBagOnUncheck ---
+
+    @Test
+    public void clearBag_onPackTab() {
+        int STATUS_PACKED = 2;
+        assertTrue(BagSelectionLogic.shouldClearBagOnUncheck(STATUS_PACKED, STATUS_PACKED));
+    }
+
+    @Test
+    public void clearBag_notOnRepackTab() {
+        int STATUS_PACKED = 2;
+        int STATUS_REPACKED = 3;
+        assertFalse(BagSelectionLogic.shouldClearBagOnUncheck(STATUS_REPACKED, STATUS_PACKED));
+    }
+
+    @Test
+    public void clearBag_notOnShouldPackTab() {
+        int STATUS_PACKED = 2;
+        int STATUS_SHOULD_PACK = 1;
+        assertFalse(BagSelectionLogic.shouldClearBagOnUncheck(STATUS_SHOULD_PACK, STATUS_PACKED));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@
 # AndroidX migration
 android.useAndroidX=true
 android.enableJetifier=true
+
+# Use legacy test runner to avoid UTP protobuf classpath conflict
+android.experimental.androidTest.useUnifiedTestPlatform=false

--- a/plans/quantity-and-bag-tracking.md
+++ b/plans/quantity-and-bag-tracking.md
@@ -1,0 +1,171 @@
+# Plan: Item Quantity + Bag Tracking Features
+
+## Context
+
+The Pack app is a native Android (Java) packing list manager with SQLite/ContentProvider data layer. It has a 3-tab packing flow (Should Pack / Pack / Repack) displayed in an ExpandableListView. The user wants two new features: per-trip item quantities, and a global bag tracking system with per-trip opt-in.
+
+---
+
+## Feature 1: Item Quantity (Trip-Specific)
+
+### Database
+- Add `quantity INTEGER NOT NULL DEFAULT 1` column to `trip_item` table
+- Bump DB version to 2, replace destructive `onUpgrade` with `ALTER TABLE` migration
+
+### Data Layer
+- `TripItem.java`: add `quantity` field + getter/setter, update Parcelable
+- `TripItemContentProvider.java`: add `"quantity"` to `validColumns`
+
+### UI: Long-press -> Quantity Modal
+- Add `setOnLongClickListener` on item rows in `PackingListExpandableAdapter.getChildView` (alongside existing click listener at line 123)
+- Show an `AlertDialog` with:
+  - Title: item name
+  - `EditText` (inputType=number), pre-filled with current quantity
+  - Horizontal row of up to 5 "quick add" buttons showing recent quantities (stored in SharedPreferences as comma-separated ints)
+  - OK/Cancel buttons
+- On confirm: update `trip_item.quantity` via ContentResolver, refresh adapter
+- Display: when quantity > 1, show `"Item Name x5"` in the TextView (line 117 of adapter)
+
+### Query Changes
+- `TripDetailActivity.fillData` raw query (line 79): add `COALESCE(TI.quantity, 1) as quantity` to SELECT
+- TripItem constructor call (line 99): pass quantity
+- `showCopyTripDialog`: copy quantity when duplicating trip items
+
+---
+
+## Feature 2: Bag Tracking (Global Bags, Per-Trip Opt-In)
+
+### Database (all in same v1->v2 migration)
+- New `bag` table: `_id INTEGER PRIMARY KEY, name TEXT NOT NULL, color TEXT NOT NULL DEFAULT '#808080'`
+- New `trip_bag` table: `_id, trip_id (FK trip), bag_id (FK bag)` with CASCADE deletes
+- Add `bag_hint_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL` to `item` table
+- Add `bag_id INTEGER REFERENCES bag(_id) ON DELETE SET NULL` to `trip_item` table
+
+### Data Layer
+- New `Bag.java`: simple data class (id, name, color)
+- New `BagContentProvider.java`: extends `AbstractSqliteContentProvider` for `bag` table
+- New `TripBagContentProvider.java`: extends `AbstractSqliteContentProvider` for `trip_bag` table
+- `ItemContentProvider.java`: add `"bag_hint_id"` to validColumns
+- `TripItemContentProvider.java`: add `"bag_id"` to validColumns
+- `TripItem.java`: add `bagId`, `bagName`, `bagColor`, `bagHintId` fields + Parcelable updates
+- Register both new providers in `AndroidManifest.xml`
+
+### Global Bag Management
+- New `BagManagementActivity.java` with ListView of bags (name + color swatch per row)
+- Add/edit via AlertDialog: EditText for name + grid of ~12 preset color buttons
+- Delete with confirmation
+- New "Bags" button on `activity_main.xml` (same pattern as Lists/Sets/Trips buttons)
+- Add `openBagsActivity` method to `MainActivity.java`
+
+### Item Bag Hint
+- On `ListItemDetailActivity` (item edit screen): add a Spinner to optionally assign a bag hint
+- Query all bags for the spinner, include a "None" option
+- Save to `item.bag_hint_id`
+
+### Trip Bag Selection
+- New menu item in `menu_trip_detail.xml`: "Bags" icon shown `ifRoom` in toolbar
+- Clicking opens an AlertDialog with multi-choice list of all global bags
+- Pre-check bags already in `trip_bag` for this trip
+- On confirm: sync `trip_bag` rows (insert new, delete removed)
+- Edge case: if removing a bag that items are packed into, show confirmation and null out those `trip_item.bag_id` values
+
+### Bag-Aware Pack Flow
+- `PackingListExpandableAdapter` constructor: accept `List<Bag> tripBags` parameter
+- Pass through: `TripDetailActivity` -> `TripDetailPagerAdapter` -> `AbstractPackingFragment` -> adapter
+- Modified click handler (line 123-161):
+  - When transitioning to STATUS_PACKED or STATUS_REPACKED **and** `tripBags` is non-empty:
+    - Show bag picker dialog before completing the status change
+    - Bag picker: single-choice list of trip's active bags, each with colored circle + name
+    - Pre-select: use `tripItem.bagId` if non-zero (repack case), else `item.bag_hint_id` if that bag is active in the trip
+    - On selection: set `trip_item.bag_id` alongside the status update
+    - On cancel: abort the pack action (item stays at current status)
+  - When `tripBags` is empty: existing behavior unchanged
+
+### Bag Chip Display
+- In `getChildView`: when item has a `bagId`, add a small colored oval View between the text and checkbox
+  - 12dp circle, background color from `bagColor`, using `GradientDrawable`
+  - GONE when no bag assigned
+- Adjust `getChildAt` indices accordingly (text=0, bagChip=1, checkbox=2)
+
+### Query Changes
+- `TripDetailActivity.fillData`: LEFT JOIN `bag B ON B._id=TI.bag_id` to get bag name/color; also select `I.bag_hint_id`
+- Separate query to load trip's active bags into `ArrayList<Bag>` for the adapter
+- Pass `tripBags` and `bagHintId` through the data pipeline
+
+---
+
+## Implementation Order
+
+**Phase 1 - Database & Data Layer**
+1. `DatabaseHelper.java` - version 2 migration with all new tables/columns
+2. `Bag.java` - new data class
+3. `BagContentProvider.java` + `TripBagContentProvider.java` - new providers
+4. Update `TripItemContentProvider`, `ItemContentProvider` valid columns
+5. Update `TripItem.java` - add quantity, bag fields, Parcelable
+6. Register providers in `AndroidManifest.xml`
+
+**Phase 2 - Quantity Feature**
+7. Quantity dialog helper (AlertDialog with quick-add buttons)
+8. Long-press handler in `PackingListExpandableAdapter`
+9. Quantity display in adapter (`"x5"` suffix)
+10. Update `fillData` query and TripItem construction
+11. Update `showCopyTripDialog` to preserve quantity
+
+**Phase 3 - Bag Management**
+12. `BagManagementActivity` + layout + color picker dialog
+13. "Bags" button on MainActivity
+14. Bag hint spinner on `ListItemDetailActivity`
+
+**Phase 4 - Trip Bag Integration**
+15. Trip bag selection dialog (from TripDetailActivity toolbar)
+16. Bag picker dialog (shown during pack action)
+17. Modify adapter click handler for bag-aware packing
+18. Bag chip display in item rows
+19. Update `fillData` query with bag JOINs
+20. Wire trip bags through pager adapter and fragments
+
+**Phase 5 - Edge Cases & Polish**
+21. Handle bag removal from trip (null out packed bag_ids)
+22. Copy trip: also copy `trip_bag` entries and `trip_item.bag_id`
+23. Verify cloud backup/restore compatibility (schema travels with DB file; `onUpgrade` handles old->new)
+
+---
+
+## Key Files to Modify
+
+| File | Changes |
+|------|---------|
+| `data/DatabaseHelper.java` | Version bump, new tables, migration |
+| `data/TripItem.java` | Add quantity, bag fields, update Parcelable |
+| `data/TripItemContentProvider.java` | Add quantity, bag_id to valid columns |
+| `data/ItemContentProvider.java` | Add bag_hint_id to valid columns |
+| `adapter/PackingListExpandableAdapter.java` | Long-press, quantity display, bag indicator, bag-aware click |
+| `adapter/TripDetailPagerAdapter.java` | Pass tripBags through to fragments |
+| `fragment/AbstractPackingFragment.java` | Receive and pass tripBags |
+| `TripDetailActivity.java` | Load bags, modified query, menu handler, copy-trip changes |
+| `MainActivity.java` | Add Manage Bags button |
+| `AndroidManifest.xml` | Register new providers and activity |
+| `res/menu/menu_trip_detail.xml` | Add bags menu item |
+| `res/layout/activity_main.xml` | Add Manage Bags button |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `data/Bag.java` | Data class |
+| `data/BagContentProvider.java` | Content provider for `bag` table |
+| `data/TripBagContentProvider.java` | Content provider for `trip_bag` table |
+| `BagManagementActivity.java` | Global bag CRUD activity |
+| `res/layout/activity_bag_management.xml` | Bag management layout |
+| `res/drawable/ic_bag.xml` | Bag icon vector drawable |
+
+---
+
+## Verification
+1. Build and install on device/emulator
+2. Test quantity: long-press item -> set quantity -> verify display, verify persistence across tab switches
+3. Test bags: create bags globally -> assign to trip -> pack item -> verify bag picker appears -> verify chip shows
+4. Test repack: verify bag pre-selects the pack-phase bag
+5. Test bag hint: set hint on item -> pack in trip with that bag active -> verify pre-selection
+6. Test edge cases: remove bag from trip, delete bag globally, copy trip with bags
+7. Test migration: install old version, add data, upgrade to new version, verify data intact

--- a/plans/quantity-and-bag-tracking.md
+++ b/plans/quantity-and-bag-tracking.md
@@ -159,13 +159,51 @@ The Pack app is a native Android (Java) packing list manager with SQLite/Content
 | `res/layout/activity_bag_management.xml` | Bag management layout |
 | `res/drawable/ic_bag.xml` | Bag icon vector drawable |
 
+Note: `ic_bag.xml` was not created — the "Bags" menu item uses text only (`ifRoom` shows title). A vector drawable could be added later for a cleaner toolbar.
+
 ---
 
 ## Verification
-1. Build and install on device/emulator
-2. Test quantity: long-press item -> set quantity -> verify display, verify persistence across tab switches
-3. Test bags: create bags globally -> assign to trip -> pack item -> verify bag picker appears -> verify chip shows
-4. Test repack: verify bag pre-selects the pack-phase bag
-5. Test bag hint: set hint on item -> pack in trip with that bag active -> verify pre-selection
-6. Test edge cases: remove bag from trip, delete bag globally, copy trip with bags
-7. Test migration: install old version, add data, upgrade to new version, verify data intact
+1. ✅ Build and install on device/emulator
+2. ✅ Test quantity: long-press item -> set quantity -> verify display, verify persistence across tab switches
+3. ✅ Test bags: create bags globally -> assign to trip -> pack item -> verify bag picker appears -> verify chip shows
+4. ✅ Test repack: verify bag pre-selects the pack-phase bag
+5. ✅ Test bag hint: set hint on item -> pack in trip with that bag active -> verify pre-selection
+6. ✅ Test edge cases: remove bag from trip, delete bag globally, copy trip with bags
+7. ✅ Test migration: install old version, add data, upgrade to new version, verify data intact
+
+---
+
+## Implementation Notes & Follow-ups
+
+### Ambiguities / Decisions Made
+- **Bag menu in toolbar**: Used text-only "Bags" menu item (showAsAction=ifRoom) rather than an icon since no vector drawable was created. Could add `ic_bag.xml` later for a cleaner look.
+  - Fine as is
+- **Quantity on unpacked items**: Setting quantity on an item with status 0 auto-marks it as SHOULD_PACK (since trip_item row must exist to store quantity). This seemed like the right UX — if you're setting a quantity you intend to pack it.
+  - Yep definitely this is great, lets you long-press for everything you want quantity for.
+- **Bag chip**: Shows a 12dp colored circle between item name and checkbox. No bag name text to keep rows compact. Tooltip or long-press could show bag name in the future.
+  - Added legend to solve for this 
+- **Bag removal from trip**: When unchecking a bag in the trip bag selection dialog, all trip_item.bag_id values for that bag are nulled. Items stay packed, just lose their bag assignment. No confirmation dialog — done silently since user explicitly unchecked it.
+  - Fine as is
+- **Repack bag pre-selection**: Uses the already-assigned bag_id from the pack phase. Falls back to bag_hint_id if no bag was assigned.
+  - Makes sense.
+- **Should Pack tab**: Bag picker is NOT shown on Should Pack since it's just marking items to pack, not actually packing them. Bags only asked during Pack and Repack actions.
+  - Makes sense.
+
+### Potential Follow-ups
+- Add a vector drawable icon for the Bags toolbar menu item
+  - No need, but we added nice tiles to landing page
+- Consider showing bag name on long-press of the bag chip
+  - No need, added always visible legend
+- The bag hint spinner on item edit screen loads bags synchronously — for very large bag lists this could be slow (unlikely in practice)
+  - Seems fine
+- No uniqueness constraint on bag names — user could create duplicate-named bags
+  - Fixed
+- The quantity quick-add buttons are global (SharedPreferences), not per-trip or per-list
+  - Makes sense
+- Consider adding a "clear all bag assignments" option when removing bags from a trip
+  - No need
+- The bag color picker uses a fixed grid of 12 colors — could be expanded or support custom hex input
+  - No need, gave nice pastels
+- There is no way to delete a bag
+  - Fine for now


### PR DESCRIPTION
## Summary

- **Item Quantity**: Long-press any item in packing views to set a quantity (e.g., 5x socks). Shows recent quantities as quick-add buttons. Displays "x5" suffix inline. Quantity preserved when copying trips.
- **Bag Tracking**: Global bag management with color-coded bags. Per-trip opt-in via toolbar menu. Pack/repack actions prompt for bag selection when bags are active. Colored chip indicators on packed items with a scrollable legend bar. Bag hints on items and bulk default bag assignment on packing lists.
- **Home Screen Redesign**: 3x2 tile grid with vector icons replacing the button list.
- **Bug Fixes**: Action bar back navigation, group expansion on first tab visit, bag removal UI sync, repack bag clearing.
- **Testing**: 12 database migration integration tests (v1→v2→v3) and 12 unit tests for bag selection logic. CLAUDE.md and README document build/test workflow.

## Test plan

- [x] Create bags from home screen, verify color picker and duplicate name prevention
- [x] Set default bag on a packing list, verify bulk update and new item inheritance
- [x] Create trip, assign bags via toolbar menu, pack items — verify bag picker appears
- [x] Verify bag hint preselection, last-selected memory, and repack defaults
- [x] Remove bag from trip — verify chips disappear immediately
- [x] Long-press items to set quantity, verify display and persistence across tabs
- [x] Copy trip — verify quantities, bags, and trip bag assignments carry over
- [x] Restore a v1 backup — verify migration succeeds without crashes
- [x] Run unit tests: `./gradlew testDebugUnitTest`
- [x] Run instrumented tests via adb (see README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)